### PR TITLE
issue #10 - add missing rate limit entries

### DIFF
--- a/foodgroup/oservice_test.go
+++ b/foodgroup/oservice_test.go
@@ -471,12 +471,374 @@ func TestOServiceService_RateParamsQuery(t *testing.T) {
 						SubGroup  uint16
 					}{
 						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceErr,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceClientOnline,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceHostOnline,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceServiceRequest,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceServiceResponse,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceRateParamsQuery,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceRateParamsReply,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceRateParamsSubAdd,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceRateDelParamSub,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceRateParamChange,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServicePauseReq,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServicePauseAck,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceResume,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceUserInfoQuery,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceUserInfoUpdate,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceEvilNotification,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceIdleNotification,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceMigrateGroups,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceMotd,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceSetPrivacyFlags,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceWellKnownUrls,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceNoop,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceClientVersions,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceHostVersions,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceMaxConfigQuery,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceMaxConfigReply,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceStoreConfig,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceConfigQuery,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceConfigReply,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceSetUserInfoFields,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceProbeReq,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceProbeAck,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceBartReply,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceBartQuery2,
+						},
+						{
+							FoodGroup: wire.OService,
+							SubGroup:  wire.OServiceBartReply2,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateErr,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateRightsQuery,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateRightsReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateSetInfo,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateUserInfoQuery,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateUserInfoReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateWatcherSubRequest,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateWatcherNotification,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateSetDirInfo,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateSetDirReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGetDirInfo,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGetDirReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGroupCapabilityQuery,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGroupCapabilityReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateSetKeywordInfo,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateSetKeywordReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGetKeywordInfo,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateGetKeywordReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateFindListByEmail,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateFindListReply,
+						},
+						{
+							FoodGroup: wire.Locate,
+							SubGroup:  wire.LocateUserInfoQuery2,
+						},
+
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyErr,
+						},
+						{
 							FoodGroup: wire.Buddy,
 							SubGroup:  wire.BuddyRightsQuery,
 						},
 						{
-							FoodGroup: wire.Chat,
-							SubGroup:  wire.ChatChannelMsgToHost,
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyRightsReply,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyAddBuddies,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyDelBuddies,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyWatcherListQuery,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyWatcherListResponse,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyWatcherSubRequest,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyWatcherNotification,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyRejectNotification,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyArrived,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyDeparted,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyAddTempBuddies,
+						},
+						{
+							FoodGroup: wire.Buddy,
+							SubGroup:  wire.BuddyDelTempBuddies,
+						},
+
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMErr,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMAddParameters,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMDelParameters,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMParameterQuery,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMParameterReply,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMChannelMsgToHost,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMChannelMsgToClient,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMEvilRequest,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMEvilReply,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMMissedCalls,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMClientErr,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMHostAck,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinStored,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinListQuery,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinListReply,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinRetrieve,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinDelete,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMNotifyRequest,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMNotifyReply,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMClientEvent,
+						},
+						{
+							FoodGroup: wire.ICBM,
+							SubGroup:  wire.ICBMSinReply,
+						},
+						{
+							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavErr,
 						},
 						{
 							FoodGroup: wire.ChatNav,
@@ -484,15 +846,240 @@ func TestOServiceService_RateParamsQuery(t *testing.T) {
 						},
 						{
 							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavRequestExchangeInfo,
+						},
+						{
+							FoodGroup: wire.ChatNav,
 							SubGroup:  wire.ChatNavRequestRoomInfo,
+						},
+						{
+							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavRequestMoreRoomInfo,
+						},
+						{
+							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavRequestOccupantList,
+						},
+						{
+							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavSearchForRoom,
 						},
 						{
 							FoodGroup: wire.ChatNav,
 							SubGroup:  wire.ChatNavCreateRoom,
 						},
 						{
+							FoodGroup: wire.ChatNav,
+							SubGroup:  wire.ChatNavNavInfo,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatErr,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatRoomInfoUpdate,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUsersJoined,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUsersLeft,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatChannelMsgToHost,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatChannelMsgToClient,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatEvilRequest,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatEvilReply,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatClientErr,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatPauseRoomReq,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatPauseRoomAck,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatResumeRoom,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatShowMyRow,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatShowRowByUsername,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatShowRowByNumber,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatShowRowByName,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatRowInfo,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatListRows,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatRowListInfo,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatMoreRows,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatMoveToRow,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatToggleChat,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatSendQuestion,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatSendComment,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatTallyVote,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatAcceptBid,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatSendInvite,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatDeclineInvite,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatAcceptInvite,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatNotifyMessage,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatGotoRow,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatStageUserJoin,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatStageUserLeft,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUnnamedSnac22,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatClose,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUserBan,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUserUnban,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatJoined,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUnnamedSnac27,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUnnamedSnac28,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatUnnamedSnac29,
+						},
+						{
+							FoodGroup: wire.Chat,
+							SubGroup:  wire.ChatRoomInfoOwner,
+						},
+
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTErr,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTUploadQuery,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTUploadReply,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTDownloadQuery,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTDownloadReply,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTDownload2Query,
+						},
+						{
+							FoodGroup: wire.BART,
+							SubGroup:  wire.BARTDownload2Reply,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagErr,
+						},
+						{
 							FoodGroup: wire.Feedbag,
 							SubGroup:  wire.FeedbagRightsQuery,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRightsReply,
 						},
 						{
 							FoodGroup: wire.Feedbag,
@@ -501,6 +1088,10 @@ func TestOServiceService_RateParamsQuery(t *testing.T) {
 						{
 							FoodGroup: wire.Feedbag,
 							SubGroup:  wire.FeedbagQueryIfModified,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagReply,
 						},
 						{
 							FoodGroup: wire.Feedbag,
@@ -520,6 +1111,30 @@ func TestOServiceService_RateParamsQuery(t *testing.T) {
 						},
 						{
 							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagInsertClass,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagUpdateClass,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagDeleteClass,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagStatus,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagReplyNotModified,
+						},
+						{
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagDeleteUser,
+						},
+						{
+							FoodGroup: wire.Feedbag,
 							SubGroup:  wire.FeedbagStartCluster,
 						},
 						{
@@ -527,92 +1142,200 @@ func TestOServiceService_RateParamsQuery(t *testing.T) {
 							SubGroup:  wire.FeedbagEndCluster,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMAddParameters,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagAuthorizeBuddy,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMParameterQuery,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagPreAuthorizeBuddy,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMChannelMsgToHost,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagPreAuthorizedBuddy,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMEvilRequest,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRemoveMe,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMClientErr,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRemoveMe2,
 						},
 						{
-							FoodGroup: wire.ICBM,
-							SubGroup:  wire.ICBMClientEvent,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRequestAuthorizeToHost,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateRightsQuery,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRequestAuthorizeToClient,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateSetInfo,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRespondAuthorizeToHost,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateSetDirInfo,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRespondAuthorizeToClient,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateGetDirInfo,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagBuddyAdded,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateSetKeywordInfo,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRequestAuthorizeToBadog,
 						},
 						{
-							FoodGroup: wire.Locate,
-							SubGroup:  wire.LocateUserInfoQuery2,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRespondAuthorizeToBadog,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceServiceRequest,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagBuddyAddedToBadog,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceClientOnline,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagTestSnac,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceRateParamsQuery,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagForwardMsg,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceRateParamsSubAdd,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagIsAuthRequiredQuery,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceUserInfoQuery,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagIsAuthRequiredReply,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceIdleNotification,
+							FoodGroup: wire.Feedbag,
+							SubGroup:  wire.FeedbagRecentBuddyUpdate,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceClientVersions,
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPErr,
 						},
 						{
-							FoodGroup: wire.OService,
-							SubGroup:  wire.OServiceSetUserInfoFields,
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPLoginRequest,
 						},
 						{
-							FoodGroup: wire.BART,
-							SubGroup:  wire.BARTUploadQuery,
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPLoginResponse,
 						},
 						{
-							FoodGroup: wire.BART,
-							SubGroup:  wire.BARTDownloadQuery,
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPRegisterRequest,
+						},
+						{
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPChallengeRequest,
+						},
+						{
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPChallengeResponse,
+						},
+						{
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPAsasnRequest,
+						},
+						{
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPSecuridRequest,
+						},
+						{
+							FoodGroup: wire.BUCP,
+							SubGroup:  wire.BUCPRegistrationImageRequest,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertErr,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertSetAlertRequest,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertSetAlertReply,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetSubsRequest,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetSubsResponse,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertNotifyCapabilities,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertNotify,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetRuleRequest,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetRuleReply,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetFeedRequest,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertGetFeedReply,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertRefreshFeed,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertEvent,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertQogSnac,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertRefreshFeedStock,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertNotifyTransport,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertSetAlertRequestV2,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertSetAlertReplyV2,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertTransitReply,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertNotifyAck,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertNotifyDisplayCapabilities,
+						},
+						{
+							FoodGroup: wire.Alert,
+							SubGroup:  wire.AlertUserOnline,
 						},
 					},
 				},


### PR DESCRIPTION
The login flow for AIM 4.0.9 for macOS 8.1 freezes because OServiceRateParamsReply lacks one or more subgroup rate limit rules. This commit adds a comprehensive list of rate limit rules for all food groups currently supported by the server.

With this fix, the login flow for AIM 4.0.9 successfully completes. Note that you'll get a SNAC error upon login, which will be fixed by a subsequent commit.

![image](https://github.com/mk6i/retro-aim-server/assets/2894330/f29c9b21-364f-4bef-ab5c-4dba4e72ff97)
