### PR TITLE
Fix crash when warning offline user

### DIFF
--- a/foodgroup/icbm.go
+++ b/foodgroup/icbm.go
@@ -213,7 +213,16 @@ func (s ICBMService) EvilRequest(ctx context.Context, sess *state.Session, inFra
 
 	recipSess := s.messageRelayer.RetrieveByScreenName(inBody.ScreenName)
 	if recipSess == nil {
-		return wire.SNACMessage{}, nil
+		return wire.SNACMessage{
+			Frame: wire.SNACFrame{
+				FoodGroup: wire.ICBM,
+				SubGroup:  wire.ICBMErr,
+				RequestID: inFrame.RequestID,
+			},
+			Body: wire.SNACError{
+				Code: wire.ErrorCodeNotLoggedOn,
+			},
+		}, nil
 	}
 
 	increase := evilDelta

--- a/wire/encode.go
+++ b/wire/encode.go
@@ -10,12 +10,16 @@ import (
 )
 
 var ErrMarshalFailure = errors.New("failed to marshal")
+var ErrMarshalFailureNilSNAC = errors.New("attempting to marshal a nil SNAC")
 
 func Marshal(v any, w io.Writer) error {
 	return marshal(reflect.TypeOf(v), reflect.ValueOf(v), "", w)
 }
 
 func marshal(t reflect.Type, v reflect.Value, tag reflect.StructTag, w io.Writer) error {
+	if t == nil {
+		return ErrMarshalFailureNilSNAC
+	}
 	switch t.Kind() {
 	case reflect.Struct:
 		for i := 0; i < t.NumField(); i++ {

--- a/wire/encode_test.go
+++ b/wire/encode_test.go
@@ -323,6 +323,12 @@ func TestMarshal(t *testing.T) {
 			},
 			wantErr: ErrMarshalFailure,
 		},
+		{
+			name:    "empty snac",
+			w:       &bytes.Buffer{},
+			given:   nil,
+			wantErr: ErrMarshalFailureNilSNAC,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Summary
When a warned screenname is offline ras would attempt to send an empty SNAC, which caused a crash when marshalling the nil value. Fix by sending a proper error message, and also detect the nil value when marshalling so we don't crash on future empty snacs.

Closes #38

### Testing Done

**Before Fix**
Following the procedure in #38 resulted in ras segfaulting.

**nil Check**
With just the nil check added to encode.go, I verified that when attempting to send an empty SNAC, the user's session will end and the server will print an error, but the server does not crash.
```
time=2024-06-01T08:49:09.945-07:00 level=ERROR msg="client request error" svc=BOS request.food_group=ICBM request.sub_group=ICBMEvilRequest err="attempting to marshal a nil SNAC" screenName=test1 ip=127.0.0.1:49844
time=2024-06-01T08:49:09.945-07:00 level=INFO msg="user disconnected" svc=BOS screenName=test1 ip=127.0.0.1:49844
time=2024-06-01T08:49:09.945-07:00 level=INFO msg="user session failed" svc=BOS err="attempting to marshal a nil SNAC"
```

**Sending Error when ScreenName is Offline**
With the change to icbm.go, sending an error instead of an empty snac, the server no longer crashes and the client shows an error message 
<img width="377" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/73120bfb-e004-4a14-8003-3e218558e48b">


**Unit Tests**
Ran unit tests, the encode tests passed and all other unit tests passed (some oscar warnings but they are unrelated)

```
✗ go test -race ./...
?       github.com/mk6i/retro-aim-server/cmd/config_generator   [no test files]
?       github.com/mk6i/retro-aim-server/cmd/server     [no test files]
?       github.com/mk6i/retro-aim-server/config [no test files]
# github.com/mk6i/retro-aim-server/server/oscar.test
ld: warning: '/private/var/folders/kx/v807trzs699gd6vh_9zc83xm0000gn/T/go-link-878071227/000025.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
# github.com/mk6i/retro-aim-server/server/http.test
ld: warning: '/private/var/folders/kx/v807trzs699gd6vh_9zc83xm0000gn/T/go-link-1732920758/000025.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
# github.com/mk6i/retro-aim-server/state.test
ld: warning: '/private/var/folders/kx/v807trzs699gd6vh_9zc83xm0000gn/T/go-link-3897708936/000025.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
# github.com/mk6i/retro-aim-server/foodgroup.test
ld: warning: '/private/var/folders/kx/v807trzs699gd6vh_9zc83xm0000gn/T/go-link-64080665/000025.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
# github.com/mk6i/retro-aim-server/server/oscar/handler.test
ld: warning: '/private/var/folders/kx/v807trzs699gd6vh_9zc83xm0000gn/T/go-link-3013746225/000025.o' has malformed LC_DYSYMTAB, expected 98 undefined symbols to start at index 1626, found 95 undefined symbols starting at index 1626
?       github.com/mk6i/retro-aim-server/server/oscar/middleware        [no test files]
ok      github.com/mk6i/retro-aim-server/foodgroup      1.525s
ok      github.com/mk6i/retro-aim-server/server/http    1.275s
ok      github.com/mk6i/retro-aim-server/server/oscar   1.375s
ok      github.com/mk6i/retro-aim-server/server/oscar/handler   1.385s
ok      github.com/mk6i/retro-aim-server/state  1.562s
ok      github.com/mk6i/retro-aim-server/wire   1.586s
```