### PR TITLE
Send OServiceUserInfoUpdate when formatting screenname

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -143,7 +143,7 @@ func main() {
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "ADMIN")
 		buddyService := foodgroup.NewBuddyService(sessionManager, feedbagStore, adjListBuddyListStore)
-		adminService := foodgroup.NewAdminService(sessionManager, feedbagStore, buddyService)
+		adminService := foodgroup.NewAdminService(sessionManager, feedbagStore, buddyService, sessionManager)
 		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
 		oServiceService := foodgroup.NewOServiceServiceForAdmin(cfg, logger, buddyService)
 


### PR DESCRIPTION
### Summary
This is needed to inform the client that their user info has changed. For example, when viewing a profile with '%n' it was incorrectly still showing the old format.

The buddy list header still shows the old format on the 5.1.3036 client but may be a client bug. It works correctly on a 5.9 client.

### Testing Done

- Tested that %n now shows the correct screen name format when viewing someone's profile. 
- Tested a 5.9 client and verified the buddy list header updates correctly now
- Unit tests pass


1. Logged in as 'lab02' all lowercase
    <img width="567" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/6e6e9771-e056-43c8-bfa3-e13f2ab14e6c">

2. Formatted the screenname to L A B 0 2
    <img width="344" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/bdbbb4a1-b84e-48eb-81b3-b26c5f635c92">

3. Formatting is successful. The buddy list window title, buddy list header, and buddy list entry all update successfully. Viewing the profile with %n now shows the updated format
    <img width="561" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/03b52c39-b82b-4a9c-a10e-2b2ff6bb6235">
    <img width="380" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/0073d0b6-97b0-420f-ab57-71a89845ae6d">

