### PR TITLE
Additional admin functions

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -52,7 +52,7 @@ func main() {
 	}()
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "BOS")
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		bartService := foodgroup.NewBARTService(logger, feedbagStore, sessionManager, feedbagStore, adjListBuddyListStore)
 		buddyService := foodgroup.NewBuddyService(sessionManager, feedbagStore, adjListBuddyListStore)
 		chatNavService := foodgroup.NewChatNavService(logger, feedbagStore, state.NewChatRoom)
@@ -85,7 +85,7 @@ func main() {
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "CHAT")
 		sessionManager := state.NewInMemorySessionManager(logger)
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		chatService := foodgroup.NewChatService(chatSessionManager)
 		oServiceService := foodgroup.NewOServiceServiceForChat(cfg, logger, sessionManager, adjListBuddyListStore, feedbagStore, feedbagStore, chatSessionManager)
 
@@ -104,7 +104,7 @@ func main() {
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "CHAT_NAV")
 		sessionManager := state.NewInMemorySessionManager(logger)
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		chatNavService := foodgroup.NewChatNavService(logger, feedbagStore, state.NewChatRoom)
 		oServiceService := foodgroup.NewOServiceServiceForChatNav(cfg, logger, sessionManager, adjListBuddyListStore, feedbagStore)
 
@@ -124,7 +124,7 @@ func main() {
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "ALERT")
 		sessionManager := state.NewInMemorySessionManager(logger)
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		oServiceService := foodgroup.NewOServiceServiceForAlert(cfg, logger, sessionManager, adjListBuddyListStore, feedbagStore)
 
 		oscar.BOSServer{
@@ -144,7 +144,7 @@ func main() {
 		logger = logger.With("svc", "ADMIN")
 		buddyService := foodgroup.NewBuddyService(sessionManager, feedbagStore, adjListBuddyListStore)
 		adminService := foodgroup.NewAdminService(sessionManager, feedbagStore, buddyService, sessionManager)
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		oServiceService := foodgroup.NewOServiceServiceForAdmin(cfg, logger, buddyService)
 
 		oscar.AdminServer{
@@ -164,7 +164,7 @@ func main() {
 		logger = logger.With("svc", "BART")
 		sessionManager := state.NewInMemorySessionManager(logger)
 		bartService := foodgroup.NewBARTService(logger, feedbagStore, sessionManager, feedbagStore, adjListBuddyListStore)
-		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager)
+		authService := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, sessionManager, feedbagStore, chatSessionManager, feedbagStore)
 		oServiceService := foodgroup.NewOServiceServiceForBART(cfg, logger, sessionManager, adjListBuddyListStore, feedbagStore)
 
 		oscar.BOSServer{
@@ -182,7 +182,7 @@ func main() {
 	}(logger)
 	go func(logger *slog.Logger) {
 		logger = logger.With("svc", "AUTH")
-		authHandler := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, nil, nil, chatSessionManager)
+		authHandler := foodgroup.NewAuthService(cfg, sessionManager, chatSessionManager, feedbagStore, adjListBuddyListStore, cookieBaker, nil, nil, chatSessionManager, feedbagStore)
 
 		oscar.AuthServer{
 			AuthService: authHandler,

--- a/foodgroup/admin.go
+++ b/foodgroup/admin.go
@@ -2,6 +2,8 @@ package foodgroup
 
 import (
 	"context"
+	"errors"
+	"net/mail"
 
 	"github.com/mk6i/retro-aim-server/state"
 	"github.com/mk6i/retro-aim-server/wire"
@@ -32,25 +34,50 @@ type AdminService struct {
 	messageRelayer         MessageRelayer
 }
 
-// ConfirmRequest returns the ScreenName account status. It returns SNAC
-// wire.AdminConfirmReply. The values in the return SNAC are
-// flag, URL, length
-func (s AdminService) ConfirmRequest(_ context.Context, frame wire.SNACFrame) (wire.SNACMessage, error) {
-	return wire.SNACMessage{
-		Frame: wire.SNACFrame{
-			FoodGroup: wire.Admin,
-			SubGroup:  wire.AdminAcctConfirmReply,
-			RequestID: frame.RequestID,
-		},
-		Body: wire.SNAC_0x07_0x07_AdminConfirmReply{
-			Status: wire.AdminAcctConfirmStatusEmailSent, // todo: get from session/db
-		},
-	}, nil
+// ConfirmRequest will mark the user account as confirmed if the user has an email address set
+func (s AdminService) ConfirmRequest(ctx context.Context, sess *state.Session, frame wire.SNACFrame) (wire.SNACMessage, error) {
+	// getAdminInfoReply returns an AdminAcctConfirmReply SNAC
+	var getAdminConfirmReply = func(status uint16) wire.SNACMessage {
+		return wire.SNACMessage{
+			Frame: wire.SNACFrame{
+				FoodGroup: wire.Admin,
+				SubGroup:  wire.AdminAcctConfirmReply,
+				RequestID: frame.RequestID,
+			},
+			Body: wire.SNAC_0x07_0x07_AdminConfirmReply{
+				Status: status,
+			},
+		}
+	}
+
+	_, err := s.accountManager.EmailAddressByName(sess.IdentScreenName())
+	if errors.Is(err, state.ErrNoEmailAddress) {
+		return getAdminConfirmReply(wire.AdminAcctConfirmStatusServerError), nil
+	} else if err != nil {
+		return wire.SNACMessage{}, err
+	}
+
+	accountConfirmed, err := s.accountManager.ConfirmStatusByName(sess.IdentScreenName())
+	if err != nil {
+		return wire.SNACMessage{}, err
+	}
+	if accountConfirmed {
+		return getAdminConfirmReply(wire.AdminAcctConfirmStatusAlreadyConfirmed), nil
+	}
+	if err := s.accountManager.UpdateConfirmStatus(true, sess.IdentScreenName()); err != nil {
+		return wire.SNACMessage{}, err
+	}
+	sess.ClearUserInfoFlag(wire.OServiceUserFlagUnconfirmed)
+	if err := s.buddyUpdateBroadcaster.BroadcastBuddyArrived(ctx, sess); err != nil {
+		return wire.SNACMessage{}, err
+	}
+	return getAdminConfirmReply(wire.AdminAcctConfirmStatusEmailSent), nil
 }
 
 // InfoQuery returns the requested information about the account
 func (s AdminService) InfoQuery(_ context.Context, sess *state.Session, frame wire.SNACFrame, body wire.SNAC_0x07_0x02_AdminInfoQuery) (wire.SNACMessage, error) {
-	var getAdminInfoReply = func(tag uint16, val any) wire.SNACMessage {
+	// getAdminInfoReply returns an AdminInfoReply SNAC
+	var getAdminInfoReply = func(tlvList wire.TLVList) wire.SNACMessage {
 		return wire.SNACMessage{
 			Frame: wire.SNACFrame{
 				FoodGroup: wire.Admin,
@@ -60,28 +87,38 @@ func (s AdminService) InfoQuery(_ context.Context, sess *state.Session, frame wi
 			Body: wire.SNAC_0x07_0x03_AdminInfoReply{
 				Permissions: wire.AdminInfoPermissionsReadWrite, // todo: what does this actually control?
 				TLVBlock: wire.TLVBlock{
-					TLVList: wire.TLVList{
-						wire.NewTLV(tag, val),
-					},
+					TLVList: tlvList,
 				},
 			},
 		}
 	}
 
-	// wire.AdminTLVRegistrationStatus is used in the AIM Preferences > Privacy panel to control
-	// Allow users who know my e-mail address to find...
-	//	o Nothing about me - wire.AdminInfoRegStatusNoDisclosure
-	//	o Only that I have an account - wire.AdminInfoRegStatusLimitDisclosure
-	//	o My screen name - wire.AdminInfoRegStatusFullDisclosure
+	tlvList := wire.TLVList{}
+
 	if _, hasRegStatus := body.TLVRestBlock.Slice(wire.AdminTLVRegistrationStatus); hasRegStatus {
-		return getAdminInfoReply(wire.AdminTLVRegistrationStatus, wire.AdminInfoRegStatusFullDisclosure), nil // todo: get from session/db
+		regStatus, err := s.accountManager.RegStatusByName(sess.IdentScreenName())
+		if err != nil {
+			return wire.SNACMessage{}, err
+		}
+		tlvList.Append(wire.NewTLV(wire.AdminTLVRegistrationStatus, regStatus))
+		return getAdminInfoReply(tlvList), nil
+	}
 
-	} else if _, hasEmail := body.TLVRestBlock.Slice(wire.AdminTLVEmailAddress); hasEmail {
-		return getAdminInfoReply(wire.AdminTLVEmailAddress, sess.IdentScreenName().String()+"@aol.com"), nil // todo: get from session/db
+	if _, hasEmail := body.TLVRestBlock.Slice(wire.AdminTLVEmailAddress); hasEmail {
+		e, err := s.accountManager.EmailAddressByName(sess.IdentScreenName())
+		if errors.Is(err, state.ErrNoEmailAddress) {
+			tlvList.Append(wire.NewTLV(wire.AdminTLVEmailAddress, ""))
+		} else if err != nil {
+			return wire.SNACMessage{}, err
+		} else {
+			tlvList.Append(wire.NewTLV(wire.AdminTLVEmailAddress, e.Address))
+		}
+		return getAdminInfoReply(tlvList), nil
+	}
 
-	} else if _, hasNickName := body.TLVRestBlock.Slice(wire.AdminTLVScreenNameFormatted); hasNickName {
-		return getAdminInfoReply(wire.AdminTLVScreenNameFormatted, sess.DisplayScreenName().String()), nil
-
+	if _, hasNickName := body.TLVRestBlock.Slice(wire.AdminTLVScreenNameFormatted); hasNickName {
+		tlvList.Append(wire.NewTLV(wire.AdminTLVScreenNameFormatted, sess.DisplayScreenName().String()))
+		return getAdminInfoReply(tlvList), nil
 	}
 
 	return wire.SNACMessage{
@@ -96,8 +133,10 @@ func (s AdminService) InfoQuery(_ context.Context, sess *state.Session, frame wi
 	}, nil
 }
 
+// InfoChangeRequest handles the user changing account information
 func (s AdminService) InfoChangeRequest(ctx context.Context, sess *state.Session, frame wire.SNACFrame, body wire.SNAC_0x07_0x04_AdminInfoChangeRequest) (wire.SNACMessage, error) {
-	var replyMessage = func(tag uint16, val any) wire.SNACMessage {
+	// replyMessage builds and returns an AdminChangeReply SNAC
+	var getAdminChangeReply = func(tlvList wire.TLVList) wire.SNACMessage {
 		return wire.SNACMessage{
 			Frame: wire.SNACFrame{
 				FoodGroup: wire.Admin,
@@ -107,39 +146,59 @@ func (s AdminService) InfoChangeRequest(ctx context.Context, sess *state.Session
 			Body: wire.SNAC_0x07_0x05_AdminChangeReply{
 				Permissions: wire.AdminInfoPermissionsReadWrite,
 				TLVBlock: wire.TLVBlock{
-					TLVList: wire.TLVList{
-						wire.NewTLV(tag, val),
-					},
+					TLVList: tlvList,
 				},
 			},
 		}
 	}
 
+	// validateProposedName ensures that the name is valid
 	var validateProposedName = func(name state.DisplayScreenName) (ok bool, errorCode uint16) {
+		// proposed name is too long
 		if len(name) > 16 {
-			// proposed name is too long
-			// todo: 16 should be defined elsewhere
 			return false, wire.AdminInfoErrorInvalidNickNameLength
-		} else if name.IdentScreenName() != sess.IdentScreenName() {
-			// proposed name does not match session name (e.g. malicious client)
+		}
+		// proposed name does not match session name (e.g. malicious client)
+		if name.IdentScreenName() != sess.IdentScreenName() {
+			return false, wire.AdminInfoErrorValidateNickName
+		}
+		// proposed name ends in a space
+		if name[len(name)-1] == 32 {
 			return false, wire.AdminInfoErrorInvalidNickName
 		}
 		return true, 0
 	}
 
+	// validateProposedEmailAddress ensures that the email address is valid
+	var validateProposedEmailAddress = func(emailAddress []byte) (e *mail.Address, errorCode uint16) {
+		/*
+			todo: pidgin/libpurple will show 'unknown error: 0xNNNN' for these error codes.
+			We could do a client check here and send wire.AdminInfoErrorDNSFail so pidgin
+			will show "given email address is invalid" instead.
+		*/
+
+		e, err := mail.ParseAddress(string(emailAddress))
+
+		// rfc 5322 basic validation
+		if err != nil {
+			return nil, wire.AdminInfoErrorInvalidEmail
+		}
+		// rfc 5521 length - local-part (64) + @ (1) + domain (255)
+		if len(e.Address) > 320 {
+			return nil, wire.AdminInfoErrorInvalidEmailLength
+		}
+		// todo: wire.AdminInfoErrorDNSFail could be sent here for an invalid domain name
+		return e, 0
+	}
+
+	tlvList := wire.TLVList{}
+
 	if sn, hasScreenNameFormatted := body.TLVRestBlock.Slice(wire.AdminTLVScreenNameFormatted); hasScreenNameFormatted {
 		proposedName := state.DisplayScreenName(sn)
 		if ok, errorCode := validateProposedName(proposedName); !ok {
-			return wire.SNACMessage{
-				Frame: wire.SNACFrame{
-					FoodGroup: wire.Admin,
-					SubGroup:  wire.AdminErr,
-					RequestID: frame.RequestID,
-				},
-				Body: wire.SNACError{
-					Code: errorCode,
-				},
-			}, nil
+			tlvList.Append(wire.NewTLV(wire.AdminTLVErrorCode, errorCode))
+			tlvList.Append(wire.NewTLV(wire.AdminTLVUrl, ""))
+			return getAdminChangeReply(tlvList), nil
 		}
 		if err := s.accountManager.UpdateDisplayScreenName(proposedName); err != nil {
 			return wire.SNACMessage{}, err
@@ -157,8 +216,42 @@ func (s AdminService) InfoChangeRequest(ctx context.Context, sess *state.Session
 				TLVUserInfo: sess.TLVUserInfo(),
 			},
 		})
-		return replyMessage(wire.AdminTLVScreenNameFormatted, proposedName.String()), nil
+		tlvList.Append(wire.NewTLV(wire.AdminTLVScreenNameFormatted, proposedName.String()))
+		return getAdminChangeReply(tlvList), nil
 	}
+
+	if emailAddress, hasEmailAddress := body.TLVRestBlock.Slice(wire.AdminTLVEmailAddress); hasEmailAddress {
+		e, errorCode := validateProposedEmailAddress(emailAddress)
+		if errorCode != 0 {
+			tlvList.Append(wire.NewTLV(wire.AdminTLVErrorCode, errorCode))
+			tlvList.Append(wire.NewTLV(wire.AdminTLVUrl, ""))
+			return getAdminChangeReply(tlvList), nil
+
+		}
+		if err := s.accountManager.UpdateEmailAddress(e, sess.IdentScreenName()); err != nil {
+			return wire.SNACMessage{}, err
+		}
+		tlvList.Append(wire.NewTLV(wire.AdminTLVEmailAddress, e.Address))
+		return getAdminChangeReply(tlvList), nil
+	}
+
+	if regStatus, hasRegStatus := body.TLVRestBlock.Uint16(wire.AdminTLVRegistrationStatus); hasRegStatus {
+		switch regStatus {
+		case
+			wire.AdminInfoRegStatusFullDisclosure,
+			wire.AdminInfoRegStatusLimitDisclosure,
+			wire.AdminInfoRegStatusNoDisclosure:
+			if err := s.accountManager.UpdateRegStatus(regStatus, sess.IdentScreenName()); err != nil {
+				return wire.SNACMessage{}, err
+			}
+			tlvList.Append(wire.NewTLV(wire.AdminTLVRegistrationStatus, regStatus))
+			return getAdminChangeReply(tlvList), nil
+		}
+		tlvList.Append(wire.NewTLV(wire.AdminTLVErrorCode, wire.AdminInfoErrorInvalidRegistrationPreference))
+		tlvList.Append(wire.NewTLV(wire.AdminTLVUrl, ""))
+		return getAdminChangeReply(tlvList), nil
+	}
+
 	return wire.SNACMessage{
 		Frame: wire.SNACFrame{
 			FoodGroup: wire.Admin,

--- a/foodgroup/auth_test.go
+++ b/foodgroup/auth_test.go
@@ -957,7 +957,7 @@ func TestAuthService_RegisterChatSession_HappyPath(t *testing.T) {
 		Crack(authCookie).
 		Return(chatCookieBuf.Bytes(), nil)
 
-	svc := NewAuthService(config.Config{}, nil, chatSessionRegistry, nil, nil, cookieBaker, nil, nil, nil)
+	svc := NewAuthService(config.Config{}, nil, chatSessionRegistry, nil, nil, cookieBaker, nil, nil, nil, nil)
 
 	have, err := svc.RegisterChatSession(authCookie)
 	assert.NoError(t, err)
@@ -984,7 +984,12 @@ func TestAuthService_RegisterBOSSession_HappyPath(t *testing.T) {
 		User(sess.IdentScreenName()).
 		Return(&state.User{DisplayScreenName: sess.DisplayScreenName()}, nil)
 
-	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil)
+	accountManager := newMockAccountManager(t)
+	accountManager.EXPECT().
+		ConfirmStatusByName(sess.IdentScreenName()).
+		Return(true, nil)
+
+	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil, accountManager)
 
 	have, err := svc.RegisterBOSSession(authCookie)
 	assert.NoError(t, err)
@@ -1011,7 +1016,7 @@ func TestAuthService_RetrieveBOSSession_HappyPath(t *testing.T) {
 		User(sess.IdentScreenName()).
 		Return(&state.User{IdentScreenName: sess.IdentScreenName()}, nil)
 
-	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil)
+	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil, nil)
 
 	have, err := svc.RetrieveBOSSession(authCookie)
 	assert.NoError(t, err)
@@ -1038,7 +1043,7 @@ func TestAuthService_RetrieveBOSSession_SessionNotFound(t *testing.T) {
 		User(sess.IdentScreenName()).
 		Return(&state.User{IdentScreenName: sess.IdentScreenName()}, nil)
 
-	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil)
+	svc := NewAuthService(config.Config{}, sessionManager, nil, userManager, nil, cookieBaker, nil, nil, nil, nil)
 
 	have, err := svc.RetrieveBOSSession(authCookie)
 	assert.NoError(t, err)
@@ -1149,7 +1154,7 @@ func TestAuthService_SignoutChat(t *testing.T) {
 					RemoveSession(matchSession(params.screenName))
 			}
 
-			svc := NewAuthService(config.Config{}, nil, sessionManager, nil, nil, nil, nil, nil, chatMessageRelayer)
+			svc := NewAuthService(config.Config{}, nil, sessionManager, nil, nil, nil, nil, nil, chatMessageRelayer, nil)
 			svc.SignoutChat(nil, tt.userSession)
 		})
 	}
@@ -1214,7 +1219,7 @@ func TestAuthService_Signout(t *testing.T) {
 					})).
 					Return(nil)
 			}
-			svc := NewAuthService(config.Config{}, sessionManager, nil, nil, legacyBuddyListManager, nil, nil, nil, nil)
+			svc := NewAuthService(config.Config{}, sessionManager, nil, nil, legacyBuddyListManager, nil, nil, nil, nil, nil)
 			svc.buddyUpdateBroadcaster = buddyUpdateBroadcaster
 
 			err := svc.Signout(nil, tt.userSession)

--- a/foodgroup/mock_account_manager_test.go
+++ b/foodgroup/mock_account_manager_test.go
@@ -3,6 +3,8 @@
 package foodgroup
 
 import (
+	mail "net/mail"
+
 	state "github.com/mk6i/retro-aim-server/state"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -18,6 +20,223 @@ type mockAccountManager_Expecter struct {
 
 func (_m *mockAccountManager) EXPECT() *mockAccountManager_Expecter {
 	return &mockAccountManager_Expecter{mock: &_m.Mock}
+}
+
+// ConfirmStatusByName provides a mock function with given fields: screnName
+func (_m *mockAccountManager) ConfirmStatusByName(screnName state.IdentScreenName) (bool, error) {
+	ret := _m.Called(screnName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConfirmStatusByName")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) (bool, error)); ok {
+		return rf(screnName)
+	}
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) bool); ok {
+		r0 = rf(screnName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(state.IdentScreenName) error); ok {
+		r1 = rf(screnName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// mockAccountManager_ConfirmStatusByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ConfirmStatusByName'
+type mockAccountManager_ConfirmStatusByName_Call struct {
+	*mock.Call
+}
+
+// ConfirmStatusByName is a helper method to define mock.On call
+//   - screnName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) ConfirmStatusByName(screnName interface{}) *mockAccountManager_ConfirmStatusByName_Call {
+	return &mockAccountManager_ConfirmStatusByName_Call{Call: _e.mock.On("ConfirmStatusByName", screnName)}
+}
+
+func (_c *mockAccountManager_ConfirmStatusByName_Call) Run(run func(screnName state.IdentScreenName)) *mockAccountManager_ConfirmStatusByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_ConfirmStatusByName_Call) Return(_a0 bool, _a1 error) *mockAccountManager_ConfirmStatusByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *mockAccountManager_ConfirmStatusByName_Call) RunAndReturn(run func(state.IdentScreenName) (bool, error)) *mockAccountManager_ConfirmStatusByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// EmailAddressByName provides a mock function with given fields: screenName
+func (_m *mockAccountManager) EmailAddressByName(screenName state.IdentScreenName) (*mail.Address, error) {
+	ret := _m.Called(screenName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for EmailAddressByName")
+	}
+
+	var r0 *mail.Address
+	var r1 error
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) (*mail.Address, error)); ok {
+		return rf(screenName)
+	}
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) *mail.Address); ok {
+		r0 = rf(screenName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*mail.Address)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(state.IdentScreenName) error); ok {
+		r1 = rf(screenName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// mockAccountManager_EmailAddressByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'EmailAddressByName'
+type mockAccountManager_EmailAddressByName_Call struct {
+	*mock.Call
+}
+
+// EmailAddressByName is a helper method to define mock.On call
+//   - screenName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) EmailAddressByName(screenName interface{}) *mockAccountManager_EmailAddressByName_Call {
+	return &mockAccountManager_EmailAddressByName_Call{Call: _e.mock.On("EmailAddressByName", screenName)}
+}
+
+func (_c *mockAccountManager_EmailAddressByName_Call) Run(run func(screenName state.IdentScreenName)) *mockAccountManager_EmailAddressByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_EmailAddressByName_Call) Return(_a0 *mail.Address, _a1 error) *mockAccountManager_EmailAddressByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *mockAccountManager_EmailAddressByName_Call) RunAndReturn(run func(state.IdentScreenName) (*mail.Address, error)) *mockAccountManager_EmailAddressByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// RegStatusByName provides a mock function with given fields: screenName
+func (_m *mockAccountManager) RegStatusByName(screenName state.IdentScreenName) (uint16, error) {
+	ret := _m.Called(screenName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegStatusByName")
+	}
+
+	var r0 uint16
+	var r1 error
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) (uint16, error)); ok {
+		return rf(screenName)
+	}
+	if rf, ok := ret.Get(0).(func(state.IdentScreenName) uint16); ok {
+		r0 = rf(screenName)
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	if rf, ok := ret.Get(1).(func(state.IdentScreenName) error); ok {
+		r1 = rf(screenName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// mockAccountManager_RegStatusByName_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RegStatusByName'
+type mockAccountManager_RegStatusByName_Call struct {
+	*mock.Call
+}
+
+// RegStatusByName is a helper method to define mock.On call
+//   - screenName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) RegStatusByName(screenName interface{}) *mockAccountManager_RegStatusByName_Call {
+	return &mockAccountManager_RegStatusByName_Call{Call: _e.mock.On("RegStatusByName", screenName)}
+}
+
+func (_c *mockAccountManager_RegStatusByName_Call) Run(run func(screenName state.IdentScreenName)) *mockAccountManager_RegStatusByName_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_RegStatusByName_Call) Return(_a0 uint16, _a1 error) *mockAccountManager_RegStatusByName_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *mockAccountManager_RegStatusByName_Call) RunAndReturn(run func(state.IdentScreenName) (uint16, error)) *mockAccountManager_RegStatusByName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateConfirmStatus provides a mock function with given fields: confirmStatus, screenName
+func (_m *mockAccountManager) UpdateConfirmStatus(confirmStatus bool, screenName state.IdentScreenName) error {
+	ret := _m.Called(confirmStatus, screenName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateConfirmStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(bool, state.IdentScreenName) error); ok {
+		r0 = rf(confirmStatus, screenName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// mockAccountManager_UpdateConfirmStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateConfirmStatus'
+type mockAccountManager_UpdateConfirmStatus_Call struct {
+	*mock.Call
+}
+
+// UpdateConfirmStatus is a helper method to define mock.On call
+//   - confirmStatus bool
+//   - screenName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) UpdateConfirmStatus(confirmStatus interface{}, screenName interface{}) *mockAccountManager_UpdateConfirmStatus_Call {
+	return &mockAccountManager_UpdateConfirmStatus_Call{Call: _e.mock.On("UpdateConfirmStatus", confirmStatus, screenName)}
+}
+
+func (_c *mockAccountManager_UpdateConfirmStatus_Call) Run(run func(confirmStatus bool, screenName state.IdentScreenName)) *mockAccountManager_UpdateConfirmStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool), args[1].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateConfirmStatus_Call) Return(_a0 error) *mockAccountManager_UpdateConfirmStatus_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateConfirmStatus_Call) RunAndReturn(run func(bool, state.IdentScreenName) error) *mockAccountManager_UpdateConfirmStatus_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // UpdateDisplayScreenName provides a mock function with given fields: displayScreenName
@@ -62,6 +281,100 @@ func (_c *mockAccountManager_UpdateDisplayScreenName_Call) Return(_a0 error) *mo
 }
 
 func (_c *mockAccountManager_UpdateDisplayScreenName_Call) RunAndReturn(run func(state.DisplayScreenName) error) *mockAccountManager_UpdateDisplayScreenName_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateEmailAddress provides a mock function with given fields: emailAddress, screenName
+func (_m *mockAccountManager) UpdateEmailAddress(emailAddress *mail.Address, screenName state.IdentScreenName) error {
+	ret := _m.Called(emailAddress, screenName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateEmailAddress")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*mail.Address, state.IdentScreenName) error); ok {
+		r0 = rf(emailAddress, screenName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// mockAccountManager_UpdateEmailAddress_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateEmailAddress'
+type mockAccountManager_UpdateEmailAddress_Call struct {
+	*mock.Call
+}
+
+// UpdateEmailAddress is a helper method to define mock.On call
+//   - emailAddress *mail.Address
+//   - screenName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) UpdateEmailAddress(emailAddress interface{}, screenName interface{}) *mockAccountManager_UpdateEmailAddress_Call {
+	return &mockAccountManager_UpdateEmailAddress_Call{Call: _e.mock.On("UpdateEmailAddress", emailAddress, screenName)}
+}
+
+func (_c *mockAccountManager_UpdateEmailAddress_Call) Run(run func(emailAddress *mail.Address, screenName state.IdentScreenName)) *mockAccountManager_UpdateEmailAddress_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*mail.Address), args[1].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateEmailAddress_Call) Return(_a0 error) *mockAccountManager_UpdateEmailAddress_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateEmailAddress_Call) RunAndReturn(run func(*mail.Address, state.IdentScreenName) error) *mockAccountManager_UpdateEmailAddress_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// UpdateRegStatus provides a mock function with given fields: regStatus, screenName
+func (_m *mockAccountManager) UpdateRegStatus(regStatus uint16, screenName state.IdentScreenName) error {
+	ret := _m.Called(regStatus, screenName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateRegStatus")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(uint16, state.IdentScreenName) error); ok {
+		r0 = rf(regStatus, screenName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// mockAccountManager_UpdateRegStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateRegStatus'
+type mockAccountManager_UpdateRegStatus_Call struct {
+	*mock.Call
+}
+
+// UpdateRegStatus is a helper method to define mock.On call
+//   - regStatus uint16
+//   - screenName state.IdentScreenName
+func (_e *mockAccountManager_Expecter) UpdateRegStatus(regStatus interface{}, screenName interface{}) *mockAccountManager_UpdateRegStatus_Call {
+	return &mockAccountManager_UpdateRegStatus_Call{Call: _e.mock.On("UpdateRegStatus", regStatus, screenName)}
+}
+
+func (_c *mockAccountManager_UpdateRegStatus_Call) Run(run func(regStatus uint16, screenName state.IdentScreenName)) *mockAccountManager_UpdateRegStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(uint16), args[1].(state.IdentScreenName))
+	})
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateRegStatus_Call) Return(_a0 error) *mockAccountManager_UpdateRegStatus_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *mockAccountManager_UpdateRegStatus_Call) RunAndReturn(run func(uint16, state.IdentScreenName) error) *mockAccountManager_UpdateRegStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/foodgroup/test_helpers.go
+++ b/foodgroup/test_helpers.go
@@ -1,6 +1,7 @@
 package foodgroup
 
 import (
+	"net/mail"
 	"time"
 
 	"github.com/stretchr/testify/mock"
@@ -302,6 +303,12 @@ type cookieIssuerParams []struct {
 // accountManager methods
 type accountManagerParams struct {
 	accountManagerUpdateDisplayScreenNameParams
+	accountManagerUpdateEmailAddressParams
+	accountManagerEmailAddressByNameParams
+	accountManagerUpdateRegStatusParams
+	accountManagerRegStatusByNameParams
+	accountManagerUpdateConfirmStatusParams
+	accountManagerConfirmStatusByNameParams
 }
 
 // accountManagerUpdateDisplayScreenNameParams is the list of parameters passed at the mock
@@ -309,6 +316,54 @@ type accountManagerParams struct {
 type accountManagerUpdateDisplayScreenNameParams []struct {
 	displayScreenName state.DisplayScreenName
 	err               error
+}
+
+// accountManagerUpdateEmailAddressParams is the list of parameters passed at the mock
+// accountManager.UpdateEmailAddress call site
+type accountManagerUpdateEmailAddressParams []struct {
+	emailAddress *mail.Address
+	screenName   state.IdentScreenName
+	err          error
+}
+
+// accountManagerEmailAddressByNameParams is the list of parameters passed at the mock
+// accountManager.EmailAddressByName call site
+type accountManagerEmailAddressByNameParams []struct {
+	screenName   state.IdentScreenName
+	emailAddress *mail.Address
+	err          error
+}
+
+// accountManagerUpdateRegStatusParams is the list of parameters passed at the mock
+// accountManager.UpdateRegStatus call site
+type accountManagerUpdateRegStatusParams []struct {
+	regStatus  uint16
+	screenName state.IdentScreenName
+	err        error
+}
+
+// accountManagerRegStatusByNameParams is the list of parameters passed at the mock
+// accountManager.RegStatusByName call site
+type accountManagerRegStatusByNameParams []struct {
+	screenName state.IdentScreenName
+	regStatus  uint16
+	err        error
+}
+
+// accountManagerUpdateConfirmStatusParams is the list of parameters passed at the mock
+// accountManager.UpdateConfirmStatus call site
+type accountManagerUpdateConfirmStatusParams []struct {
+	confirmStatus bool
+	screenName    state.IdentScreenName
+	err           error
+}
+
+// accountManagerConfirmStatusByNameParams is the list of parameters passed at the mock
+// accountManager.ConfirmStatusByName call site
+type accountManagerConfirmStatusByNameParams []struct {
+	screenName    state.IdentScreenName
+	confirmStatus bool
+	err           error
 }
 
 // buddyBroadcasterParams is a helper struct that contains mock parameters for

--- a/foodgroup/types.go
+++ b/foodgroup/types.go
@@ -35,6 +35,7 @@ package foodgroup
 
 import (
 	"context"
+	"net/mail"
 	"time"
 
 	"github.com/mk6i/retro-aim-server/state"
@@ -164,4 +165,10 @@ type buddyBroadcaster interface {
 
 type AccountManager interface {
 	UpdateDisplayScreenName(displayScreenName state.DisplayScreenName) error
+	UpdateEmailAddress(emailAddress *mail.Address, screenName state.IdentScreenName) error
+	EmailAddressByName(screenName state.IdentScreenName) (*mail.Address, error)
+	UpdateRegStatus(regStatus uint16, screenName state.IdentScreenName) error
+	RegStatusByName(screenName state.IdentScreenName) (uint16, error)
+	UpdateConfirmStatus(confirmStatus bool, screenName state.IdentScreenName) error
+	ConfirmStatusByName(screnName state.IdentScreenName) (bool, error)
 }

--- a/server/oscar/handler/admin.go
+++ b/server/oscar/handler/admin.go
@@ -27,13 +27,13 @@ type AdminHandler struct {
 }
 
 type AdminService interface {
-	ConfirmRequest(_ context.Context, frame wire.SNACFrame) (wire.SNACMessage, error)
+	ConfirmRequest(ctx context.Context, sess *state.Session, frame wire.SNACFrame) (wire.SNACMessage, error)
 	InfoQuery(ctx context.Context, sess *state.Session, frame wire.SNACFrame, body wire.SNAC_0x07_0x02_AdminInfoQuery) (wire.SNACMessage, error)
 	InfoChangeRequest(ctx context.Context, sess *state.Session, frame wire.SNACFrame, body wire.SNAC_0x07_0x04_AdminInfoChangeRequest) (wire.SNACMessage, error)
 }
 
-func (rt AdminHandler) ConfirmRequest(ctx context.Context, _ *state.Session, inFrame wire.SNACFrame, _ io.Reader, rw oscar.ResponseWriter) error {
-	outSNAC, err := rt.AdminService.ConfirmRequest(ctx, inFrame)
+func (rt AdminHandler) ConfirmRequest(ctx context.Context, sess *state.Session, inFrame wire.SNACFrame, _ io.Reader, rw oscar.ResponseWriter) error {
+	outSNAC, err := rt.AdminService.ConfirmRequest(ctx, sess, inFrame)
 	if err != nil {
 		return err
 	}

--- a/server/oscar/handler/admin_test.go
+++ b/server/oscar/handler/admin_test.go
@@ -31,7 +31,7 @@ func TestAdminHandler_ConfirmRequest(t *testing.T) {
 
 	svc := newMockAdminService(t)
 	svc.EXPECT().
-		ConfirmRequest(mock.Anything, input.Frame).
+		ConfirmRequest(nil, mock.Anything, input.Frame).
 		Return(output, nil)
 
 	h := NewAdminHandler(slog.Default(), svc)
@@ -77,7 +77,7 @@ func TestAdminHandler_InfoQuery_RegistrationStatus(t *testing.T) {
 
 	svc := newMockAdminService(t)
 	svc.EXPECT().
-		ConfirmRequest(mock.Anything, input.Frame).
+		ConfirmRequest(mock.Anything, mock.Anything, input.Frame).
 		Return(output, nil)
 
 	h := NewAdminHandler(slog.Default(), svc)

--- a/server/oscar/handler/mock_admin_test.go
+++ b/server/oscar/handler/mock_admin_test.go
@@ -24,9 +24,9 @@ func (_m *mockAdminService) EXPECT() *mockAdminService_Expecter {
 	return &mockAdminService_Expecter{mock: &_m.Mock}
 }
 
-// ConfirmRequest provides a mock function with given fields: _a0, frame
-func (_m *mockAdminService) ConfirmRequest(_a0 context.Context, frame wire.SNACFrame) (wire.SNACMessage, error) {
-	ret := _m.Called(_a0, frame)
+// ConfirmRequest provides a mock function with given fields: ctx, sess, frame
+func (_m *mockAdminService) ConfirmRequest(ctx context.Context, sess *state.Session, frame wire.SNACFrame) (wire.SNACMessage, error) {
+	ret := _m.Called(ctx, sess, frame)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ConfirmRequest")
@@ -34,17 +34,17 @@ func (_m *mockAdminService) ConfirmRequest(_a0 context.Context, frame wire.SNACF
 
 	var r0 wire.SNACMessage
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, wire.SNACFrame) (wire.SNACMessage, error)); ok {
-		return rf(_a0, frame)
+	if rf, ok := ret.Get(0).(func(context.Context, *state.Session, wire.SNACFrame) (wire.SNACMessage, error)); ok {
+		return rf(ctx, sess, frame)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, wire.SNACFrame) wire.SNACMessage); ok {
-		r0 = rf(_a0, frame)
+	if rf, ok := ret.Get(0).(func(context.Context, *state.Session, wire.SNACFrame) wire.SNACMessage); ok {
+		r0 = rf(ctx, sess, frame)
 	} else {
 		r0 = ret.Get(0).(wire.SNACMessage)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, wire.SNACFrame) error); ok {
-		r1 = rf(_a0, frame)
+	if rf, ok := ret.Get(1).(func(context.Context, *state.Session, wire.SNACFrame) error); ok {
+		r1 = rf(ctx, sess, frame)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -58,15 +58,16 @@ type mockAdminService_ConfirmRequest_Call struct {
 }
 
 // ConfirmRequest is a helper method to define mock.On call
-//   - _a0 context.Context
+//   - ctx context.Context
+//   - sess *state.Session
 //   - frame wire.SNACFrame
-func (_e *mockAdminService_Expecter) ConfirmRequest(_a0 interface{}, frame interface{}) *mockAdminService_ConfirmRequest_Call {
-	return &mockAdminService_ConfirmRequest_Call{Call: _e.mock.On("ConfirmRequest", _a0, frame)}
+func (_e *mockAdminService_Expecter) ConfirmRequest(ctx interface{}, sess interface{}, frame interface{}) *mockAdminService_ConfirmRequest_Call {
+	return &mockAdminService_ConfirmRequest_Call{Call: _e.mock.On("ConfirmRequest", ctx, sess, frame)}
 }
 
-func (_c *mockAdminService_ConfirmRequest_Call) Run(run func(_a0 context.Context, frame wire.SNACFrame)) *mockAdminService_ConfirmRequest_Call {
+func (_c *mockAdminService_ConfirmRequest_Call) Run(run func(ctx context.Context, sess *state.Session, frame wire.SNACFrame)) *mockAdminService_ConfirmRequest_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(wire.SNACFrame))
+		run(args[0].(context.Context), args[1].(*state.Session), args[2].(wire.SNACFrame))
 	})
 	return _c
 }
@@ -76,7 +77,7 @@ func (_c *mockAdminService_ConfirmRequest_Call) Return(_a0 wire.SNACMessage, _a1
 	return _c
 }
 
-func (_c *mockAdminService_ConfirmRequest_Call) RunAndReturn(run func(context.Context, wire.SNACFrame) (wire.SNACMessage, error)) *mockAdminService_ConfirmRequest_Call {
+func (_c *mockAdminService_ConfirmRequest_Call) RunAndReturn(run func(context.Context, *state.Session, wire.SNACFrame) (wire.SNACMessage, error)) *mockAdminService_ConfirmRequest_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/state/migrations/0005_user_settings.down.sql
+++ b/state/migrations/0005_user_settings.down.sql
@@ -1,0 +1,17 @@
+CREATE TABLE users_backup
+(
+    identScreenName   VARCHAR(16) PRIMARY KEY,
+    displayScreenName TEXT,
+    authKey           TEXT,
+    strongMD5Pass     TEXT,
+    weakMD5Pass       TEXT
+);
+
+INSERT INTO users_backup (identScreenName, displayScreenName, authKey, strongMD5Pass, weakMD5Pass)
+SELECT dentScreenName, displayScreenName, authKey, strongMD5Pass, weakMD5Pass
+FROM users;
+
+DROP TABLE users;
+
+ALTER TABLE users_backup
+    RENAME TO users;

--- a/state/migrations/0005_user_settings.up.sql
+++ b/state/migrations/0005_user_settings.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+    ADD COLUMN confirmStatus     BOOL DEFAULT FALSE;
+ALTER TABLE users
+    ADD COLUMN emailAddress      VARCHAR(320) NOT NULL DEFAULT '';
+ALTER TABLE users
+    ADD COLUMN regStatus         INT NOT NULL DEFAULT 3;

--- a/state/user.go
+++ b/state/user.go
@@ -18,6 +18,8 @@ var (
 	ErrDupUser = errors.New("user already exists")
 	// ErrNoUser indicates that a user does not exist.
 	ErrNoUser = errors.New("user does not exist")
+	// ErrNoEmail indicates that a user has not set an email address.
+	ErrNoEmailAddress = errors.New("user has no email address")
 )
 
 const (

--- a/wire/snacs.go
+++ b/wire/snacs.go
@@ -134,12 +134,13 @@ const (
 	OServiceBartQuery2        uint16 = 0x0022
 	OServiceBartReply2        uint16 = 0x0023
 
-	OServiceUserInfoUserFlags uint16 = 0x01
-	OServiceUserInfoSignonTOD uint16 = 0x03
-	OServiceUserInfoIdleTime  uint16 = 0x04
-	OServiceUserInfoStatus    uint16 = 0x06
-	OServiceUserInfoOscarCaps uint16 = 0x0D
-	OServiceUserInfoBARTInfo  uint16 = 0x1D
+	OServiceUserInfoUserFlags  uint16 = 0x01
+	OServiceUserInfoSignonTOD  uint16 = 0x03
+	OServiceUserInfoIdleTime   uint16 = 0x04
+	OServiceUserInfoStatus     uint16 = 0x06
+	OServiceUserInfoOscarCaps  uint16 = 0x0D
+	OServiceUserInfoBARTInfo   uint16 = 0x1D
+	OServiceUserInfoUserFlags2 uint16 = 0x1F
 
 	OServiceUserStatusAvailable         uint32 = 0x00000000 // user is available
 	OServiceUserStatusAway              uint32 = 0x00000001 // user is away
@@ -154,8 +155,25 @@ const (
 	OServiceUserStatusICQHomePage       uint32 = 0x00200000
 	OServiceUserStatusDirectRequireAuth uint32 = 0x10000000
 
-	OServiceUserFlagOSCARFree   uint16 = 0x0010 // AIM (not AOL) account
-	OServiceUserFlagUnavailable uint16 = 0x0020 // user is away
+	OServiceUserFlagUnconfirmed    uint16 = 0x0001 // Unconfirmed account
+	OServiceUserFlagAdministrator  uint16 = 0x0002 // Server Administrator
+	OServiceUserFlagAOL            uint16 = 0x0004 // AOL (staff?) account
+	OServiceUserFlagOSCARPay       uint16 = 0x0008 // Commercial account
+	OServiceUserFlagOSCARFree      uint16 = 0x0010 // AIM (not AOL) account
+	OServiceUserFlagUnavailable    uint16 = 0x0020 // user is away
+	OServiceUserFlagICQ            uint16 = 0x0040 // ICQ user (OServiceUserFlagOSCARFree should also be set)
+	OServiceUserFlagWireless       uint16 = 0x0080 // On mobile device
+	OServiceUserFlagInternal       uint16 = 0x0100 // Internal account
+	OServiceUserFlagFish           uint16 = 0x0200 // IM forwarding enabled
+	OServiceUserFlagBot            uint16 = 0x0400 // Bot account
+	OServiceUserFlagBeast          uint16 = 0x0800 // Unknown
+	OServiceUserFlagOneWayWireless uint16 = 0x1000 // On one way mobile device
+	OServiceUserFlagOfficial       uint16 = 0x2000 // Unknown
+
+	OServiceUserFlag2BuddyMatchDirect   uint32 = 0x00010000 // Unknown
+	OServiceUserFlag2BuddyMatchIndirect uint32 = 0x00020000 // Unknown
+	OServiceUserFlag2NoKnockKnock       uint32 = 0x00040000 // Sender is safe
+	OServiceUserFlag2ForwardMobile      uint32 = 0x00080000 // Forward to mobile if no acive session
 
 	OServicePrivacyFlagIdle   uint32 = 0x00000001
 	OServicePrivacyFlagMember uint32 = 0x00000002


### PR DESCRIPTION
### Summary
This PR finishes the previously stubbed out admin functionality for requesting and setting email address, confirmation status, and registration preference/status.

It also adds a check that was missing to the formatting screenname validation that the sn doesn't end in a space.

**Email Address**

- User can now set and update their email address using the AIM client
- Performs validation that it meets basic format user@host
- Performs validation that it is <= 320 characters
- Note that any waiting periods or confirmations etc are not required at this time

**Confirmation Status**

- User confirmation status is now reflected in the UserInfoFlags TLV. This can be seen when hovering mouse cursor over the user in your buddy list
- User can confirm their account if they have an email address set
- Note that any waiting periods or confirmations etc are not required at this time

**Registration Preference/Status**

- User can update their privacy preference in the AIM client and it is stored/reflected back to them

**Other changes**

- Added database migrations to add new columns for the email, confirmation, and reg pref data
- Added a clientInfoFlags member to the Session struct and added setters/getters so these flags can be updated more centrally. Note this also includes moving the away/unavailable flag setting logic to avoid a deadlock
- Updated unit tests

**Future changes**
Just wanted to mention that I'm intentionally not doing in this PR:

- Mgmt api - I need to figure out a good spot for the username and email address validation logic so that we can apply the same logic to new accounts via mgmt api, new accounts via disable_auth, and for updates from the AIM client

### Testing Done

Logging in as a brand new account, the account shows up as 'Unconfirmed Internet' in the buddy list
![image](https://github.com/mk6i/retro-aim-server/assets/109567/4f872369-d846-4dbf-957b-2d61c85a9056)

Attempting to format the screenname with one ending in a space results in an error
<img width="349" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/c908e315-521c-48ed-9115-4257ac05f1ab">

Attempting to confirm the account (My AIM > Edit Options > Confirm Account) without an email address set results in an error
<img width="350" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/7094e5f4-4202-4d79-a0e2-fb5cd45ab86b">


Opening the update email address window, it starts out reporting the user has no email set

<img width="334" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/57537f61-7ee7-4f19-866f-2365a019fad3">

Attempting to enter an invalid email format results in an error
<img width="353" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/e930b705-ed7e-4078-80b8-20bb27ac0672">

Setting the email to TestUser10@aol.com results in a success message. Note that as of this writing, the email change isn't actually pending and the user doesn't need to wait 72 hours. The email is immediately updated in the database, which can be seen if you open the update email address window again

<img width="352" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/1b67253e-c9d6-4c6a-8197-03e2de9e8937">
<img width="336" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/f9859357-d49c-4441-95da-b34663625745">


Now with an email set, the account can be confirmed.  Attempting to reconfirm the account will tell the user it's already confirmed
<img width="353" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/b7f87f5b-7b03-423b-a95e-e666c894abe7">
<img width="348" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/ef06f5e2-cbd7-4d8b-bb56-da8c06e087fd">

Confirming the account sends a broadcast to all buddies with the updated userinfo tlv and now hovering over the name no longer shows the unconfirmed status
![image](https://github.com/mk6i/retro-aim-server/assets/109567/784cb585-1c56-4c98-b04d-b5d87ce5bc13)


Resigning into AIM, the user continues to report as just 'Internet' not 'Unconfirmed Internet'

I also tested that setting Away/returning still works as I moved the logic for setting those flags.


Going to Preferences > Privacy, the toggle at the bottom can now be adjusted and saved
<img width="571" alt="image" src="https://github.com/mk6i/retro-aim-server/assets/109567/0cf37707-bac4-4867-b66d-58323f4d6bb4">


For the database migration I started with a database from retro-aim-server release version 0.8.0. Running the newer binary from my local build resulted in the database table having additional columns created and email address could be saved.

All unit tests pass.


