### PR TITLE
issue #48 - fix chat in pidgin client

### DIFF
--- a/foodgroup/chat.go
+++ b/foodgroup/chat.go
@@ -124,7 +124,7 @@ func sendChatRoomInfoUpdate(ctx context.Context, sess *state.Session, chatMessag
 			Exchange:       room.Exchange,
 			Cookie:         room.Cookie,
 			InstanceNumber: room.InstanceNumber,
-			DetailLevel:    room.DetailLevel,
+			DetailLevel:    detailLevel,
 			TLVBlock: wire.TLVBlock{
 				TLVList: room.TLVList(),
 			},

--- a/foodgroup/chat_nav_test.go
+++ b/foodgroup/chat_nav_test.go
@@ -15,10 +15,9 @@ import (
 
 func TestChatNavService_CreateRoom(t *testing.T) {
 	basicChatRoom := state.ChatRoom{
-		Cookie:         "dummy-cookie",
+		Cookie:         "4-2-the-chat-room-name",
 		CreateTime:     time.UnixMilli(0),
 		Creator:        state.NewIdentScreenName("the-screen-name"),
-		DetailLevel:    3,
 		Exchange:       4,
 		InstanceNumber: 2,
 		Name:           "the-chat-room-name",
@@ -27,7 +26,6 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 		Cookie:         "dummy-cookie",
 		CreateTime:     time.UnixMilli(0),
 		Creator:        state.NewIdentScreenName("the-screen-name"),
-		DetailLevel:    3,
 		Exchange:       5,
 		InstanceNumber: 2,
 		Name:           "the-public-chat-room-name",
@@ -55,7 +53,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       basicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, basicChatRoom.Name),
@@ -78,7 +76,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 									Exchange:       basicChatRoom.Exchange,
 									Cookie:         basicChatRoom.Cookie,
 									InstanceNumber: basicChatRoom.InstanceNumber,
-									DetailLevel:    basicChatRoom.DetailLevel,
+									DetailLevel:    detailLevel,
 									TLVBlock: wire.TLVBlock{
 										TLVList: basicChatRoom.TLVList(),
 									},
@@ -112,7 +110,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       basicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, basicChatRoom.Name),
@@ -135,7 +133,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 									Exchange:       basicChatRoom.Exchange,
 									Cookie:         basicChatRoom.Cookie,
 									InstanceNumber: basicChatRoom.InstanceNumber,
-									DetailLevel:    basicChatRoom.DetailLevel,
+									DetailLevel:    detailLevel,
 									TLVBlock: wire.TLVBlock{
 										TLVList: basicChatRoom.TLVList(),
 									},
@@ -177,7 +175,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       publicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: publicChatRoom.InstanceNumber,
-					DetailLevel:    publicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, publicChatRoom.Name),
@@ -200,7 +198,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 									Exchange:       publicChatRoom.Exchange,
 									Cookie:         publicChatRoom.Cookie,
 									InstanceNumber: publicChatRoom.InstanceNumber,
-									DetailLevel:    publicChatRoom.DetailLevel,
+									DetailLevel:    detailLevel,
 									TLVBlock: wire.TLVBlock{
 										TLVList: publicChatRoom.TLVList(),
 									},
@@ -234,7 +232,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       publicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: publicChatRoom.InstanceNumber,
-					DetailLevel:    publicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, publicChatRoom.Name),
@@ -279,7 +277,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       1337,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, basicChatRoom.Name),
@@ -310,7 +308,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       basicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{}, // intentionally empty for test
 					},
@@ -331,7 +329,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       basicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, basicChatRoom.Name),
@@ -374,7 +372,7 @@ func TestChatNavService_CreateRoom(t *testing.T) {
 					Exchange:       basicChatRoom.Exchange,
 					Cookie:         "create", // actual canned value sent by AIM client
 					InstanceNumber: basicChatRoom.InstanceNumber,
-					DetailLevel:    basicChatRoom.DetailLevel,
+					DetailLevel:    detailLevel,
 					TLVBlock: wire.TLVBlock{
 						TLVList: wire.TLVList{
 							wire.NewTLV(wire.ChatRoomTLVRoomName, basicChatRoom.Name),
@@ -453,7 +451,7 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 						TLVList: wire.TLVList{
 							wire.NewTLV(0x04, wire.SNAC_0x0E_0x02_ChatRoomInfoUpdate{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
+								DetailLevel:    detailLevel,
 								Exchange:       state.PrivateExchange,
 								InstanceNumber: 8,
 								TLVBlock: wire.TLVBlock{
@@ -471,7 +469,6 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 							cookie: "the-chat-cookie",
 							room: state.ChatRoom{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
 								Exchange:       state.PrivateExchange,
 								InstanceNumber: 8,
 							},
@@ -502,7 +499,7 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 						TLVList: wire.TLVList{
 							wire.NewTLV(0x04, wire.SNAC_0x0E_0x02_ChatRoomInfoUpdate{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
+								DetailLevel:    detailLevel,
 								Exchange:       state.PublicExchange,
 								InstanceNumber: 8,
 								TLVBlock: wire.TLVBlock{
@@ -520,7 +517,6 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 							cookie: "the-chat-cookie",
 							room: state.ChatRoom{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
 								Exchange:       state.PublicExchange,
 								InstanceNumber: 8,
 							},
@@ -571,7 +567,6 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 							cookie: "the-chat-cookie",
 							room: state.ChatRoom{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
 								Exchange:       state.PublicExchange,
 								InstanceNumber: 8,
 							},
@@ -600,7 +595,6 @@ func TestChatNavService_RequestRoomInfo(t *testing.T) {
 							cookie: "the-chat-cookie",
 							room: state.ChatRoom{
 								Cookie:         "the-chat-cookie",
-								DetailLevel:    2,
 								Exchange:       state.PrivateExchange,
 								InstanceNumber: 8,
 							},

--- a/foodgroup/oservice_test.go
+++ b/foodgroup/oservice_test.go
@@ -233,7 +233,6 @@ func TestOServiceServiceForBOS_ServiceRequest(t *testing.T) {
 							cookie: "the-chat-cookie",
 							room: state.ChatRoom{
 								CreateTime:     time.UnixMilli(0),
-								DetailLevel:    4,
 								Exchange:       8,
 								Cookie:         "the-chat-cookie",
 								InstanceNumber: 16,
@@ -1706,7 +1705,6 @@ func TestOServiceServiceForChat_ClientOnline(t *testing.T) {
 	chatter2 := newTestSession("chatter-2", sessOptChatRoomCookie("the-cookie"))
 	chatRoom := state.ChatRoom{
 		Cookie:         "the-cookie",
-		DetailLevel:    1,
 		Exchange:       2,
 		InstanceNumber: 3,
 		Name:           "the-chat-room",
@@ -1770,7 +1768,7 @@ func TestOServiceServiceForChat_ClientOnline(t *testing.T) {
 									Exchange:       chatRoom.Exchange,
 									Cookie:         chatRoom.Cookie,
 									InstanceNumber: chatRoom.InstanceNumber,
-									DetailLevel:    chatRoom.DetailLevel,
+									DetailLevel:    detailLevel,
 									TLVBlock: wire.TLVBlock{
 										TLVList: chatRoom.TLVList(),
 									},
@@ -1801,7 +1799,6 @@ func TestOServiceServiceForChat_ClientOnline(t *testing.T) {
 							cookie: "the-cookie",
 							room: state.ChatRoom{
 								Cookie:         "the-cookie",
-								DetailLevel:    1,
 								Exchange:       2,
 								InstanceNumber: 3,
 								Name:           "the-chat-room",

--- a/state/chat.go
+++ b/state/chat.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/mk6i/retro-aim-server/wire"
-
-	"github.com/google/uuid"
 )
 
 const (
@@ -34,8 +32,6 @@ type ChatRoom struct {
 	CreateTime time.Time
 	// Creator is the screen name of the user who created the chat room.
 	Creator IdentScreenName
-	// DetailLevel is the detail level of the chat room.  Unclear what this value means.
-	DetailLevel uint8
 	// Exchange indicates which exchange the chatroom belongs to. Typically, a canned value.
 	Exchange uint16
 	// InstanceNumber indicates which instance chatroom exists in. Typically, a canned value.
@@ -79,13 +75,13 @@ func (c ChatRoom) TLVList() []wire.TLV {
 		wire.NewTLV(wire.ChatRoomTLVNavCreatePerms, uint8(2)),
 		wire.NewTLV(wire.ChatRoomTLVFullyQualifiedName, c.Name),
 		wire.NewTLV(wire.ChatRoomTLVRoomName, c.Name),
+		wire.NewTLV(wire.ChatRoomTLVMaxMsgVisLen, uint16(1024)),
 	}
 }
 
 // NewChatRoom creates new state.ChatRoom objects
 func NewChatRoom() ChatRoom {
 	return ChatRoom{
-		Cookie:     uuid.New().String(),
 		CreateTime: time.Now().UTC(),
 	}
 }

--- a/state/chat_test.go
+++ b/state/chat_test.go
@@ -21,6 +21,7 @@ func TestChatRoom_TLVList(t *testing.T) {
 		wire.NewTLV(wire.ChatRoomTLVNavCreatePerms, uint8(2)),
 		wire.NewTLV(wire.ChatRoomTLVFullyQualifiedName, room.Name),
 		wire.NewTLV(wire.ChatRoomTLVRoomName, room.Name),
+		wire.NewTLV(wire.ChatRoomTLVMaxMsgVisLen, uint16(1024)),
 	}
 
 	assert.Equal(t, want, have)

--- a/wire/snacs.go
+++ b/wire/snacs.go
@@ -890,6 +890,7 @@ const (
 	ChatRoomTLVLang1              uint16 = 0xD7
 	ChatRoomTLVCharSet2           uint16 = 0xD8
 	ChatRoomTLVLang2              uint16 = 0xD9
+	ChatRoomTLVMaxMsgVisLen       uint16 = 0xDA
 )
 
 type SNAC_0x0E_0x02_ChatRoomInfoUpdate struct {


### PR DESCRIPTION
This commit implements the following changes that makes Pidgin chat work:

- chat detail level value must be "2"
- set TLV 0xDA in chat room info
- change the chat cookie to this format: %s-%s-%s, where the third %s is the chat room name.