### PR TITLE
Bug fix for non-gif buddy icons

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -129,6 +129,18 @@ paths:
               schema:
                 type: string
                 format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/png:
+              schema:
+                type: string
+                format: binary
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
         '404':
           description: User not found, or user has no buddy icon
 

--- a/server/http/mgmt_api.go
+++ b/server/http/mgmt_api.go
@@ -480,8 +480,6 @@ func postInstantMessageHandler(w http.ResponseWriter, r *http.Request, messageRe
 
 // getUserBuddyIconHandler handles the GET /user/{screenname}/icon endpoint.
 func getUserBuddyIconHandler(w http.ResponseWriter, r *http.Request, u UserManager, f FeedBagRetriever, b BARTRetriever, logger *slog.Logger) {
-	w.Header().Set("Content-Type", "image/gif")
-
 	screenName := state.NewIdentScreenName(r.PathValue("screenname"))
 	user, err := u.User(screenName)
 	if err != nil {
@@ -509,6 +507,7 @@ func getUserBuddyIconHandler(w http.ResponseWriter, r *http.Request, u UserManag
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
+	w.Header().Set("Content-Type", http.DetectContentType(icon))
 	w.Write(icon)
 }
 

--- a/server/http/mgmt_api_test.go
+++ b/server/http/mgmt_api_test.go
@@ -298,6 +298,12 @@ func TestUserAccountHandler_GET(t *testing.T) {
 }
 
 func TestUserBuddyIconHandler_GET(t *testing.T) {
+	sampleGIF := []byte{
+		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x32, 0x00, 0x32, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x21, 0xf9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x00, 0x00,
+		0x32, 0x00, 0x32, 0x00, 0x00, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3b}
+
+	sampleJPG := []byte{0xFF, 0xD8, 0xFF, 0x43, 0x13, 0x37}
 	tt := []struct {
 		name              string
 		requestScreenName state.IdentScreenName
@@ -324,9 +330,9 @@ func TestUserBuddyIconHandler_GET(t *testing.T) {
 			},
 		},
 		{
-			name:              "account with buddy icon",
+			name:              "account with gif buddy icon",
 			requestScreenName: state.NewIdentScreenName("userA"),
-			want:              string([]byte{'i', 'c', 'o', 'n'}),
+			want:              string(sampleGIF),
 			statusCode:        http.StatusOK,
 			contentType:       "image/gif",
 			mockParams: mockParams{
@@ -359,7 +365,91 @@ func TestUserBuddyIconHandler_GET(t *testing.T) {
 					bartRetrieveParams: bartRetrieveParams{
 						{
 							itemHash: []byte{'t', 'h', 'e', 'h', 'a', 's', 'h'},
-							result:   []byte{'i', 'c', 'o', 'n'},
+							result:   sampleGIF,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "account with jpg buddy icon",
+			requestScreenName: state.NewIdentScreenName("userA"),
+			want:              string(sampleJPG),
+			statusCode:        http.StatusOK,
+			contentType:       "image/jpeg",
+			mockParams: mockParams{
+				userManagerParams: userManagerParams{
+					getUserParams: getUserParams{
+						{
+							screenName: state.NewIdentScreenName("userA"),
+							result: &state.User{
+								DisplayScreenName: "userA",
+								IdentScreenName:   state.NewIdentScreenName("userA"),
+							},
+						},
+					},
+				},
+				feedBagRetrieverParams: feedBagRetrieverParams{
+					buddyIconRefByNameParams: buddyIconRefByNameParams{
+						{
+							screenName: state.NewIdentScreenName("userA"),
+							result: &wire.BARTID{
+								Type: wire.BARTTypesBuddyIcon,
+								BARTInfo: wire.BARTInfo{
+									Flags: 0x00,
+									Hash:  []byte{'t', 'h', 'e', 'h', 'a', 's', 'h'},
+								},
+							},
+						},
+					},
+				},
+				bartRetrieverParams: bartRetrieverParams{
+					bartRetrieveParams: bartRetrieveParams{
+						{
+							itemHash: []byte{'t', 'h', 'e', 'h', 'a', 's', 'h'},
+							result:   sampleJPG,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:              "account with unknown format buddy icon",
+			requestScreenName: state.NewIdentScreenName("userA"),
+			want:              string([]byte{0x13, 0x37, 0x13, 0x37, 0x13, 0x37}),
+			statusCode:        http.StatusOK,
+			contentType:       "application/octet-stream",
+			mockParams: mockParams{
+				userManagerParams: userManagerParams{
+					getUserParams: getUserParams{
+						{
+							screenName: state.NewIdentScreenName("userA"),
+							result: &state.User{
+								DisplayScreenName: "userA",
+								IdentScreenName:   state.NewIdentScreenName("userA"),
+							},
+						},
+					},
+				},
+				feedBagRetrieverParams: feedBagRetrieverParams{
+					buddyIconRefByNameParams: buddyIconRefByNameParams{
+						{
+							screenName: state.NewIdentScreenName("userA"),
+							result: &wire.BARTID{
+								Type: wire.BARTTypesBuddyIcon,
+								BARTInfo: wire.BARTInfo{
+									Flags: 0x00,
+									Hash:  []byte{'t', 'h', 'e', 'h', 'a', 's', 'h'},
+								},
+							},
+						},
+					},
+				},
+				bartRetrieverParams: bartRetrieverParams{
+					bartRetrieveParams: bartRetrieveParams{
+						{
+							itemHash: []byte{'t', 'h', 'e', 'h', 'a', 's', 'h'},
+							result:   []byte{0x13, 0x37, 0x13, 0x37, 0x13, 0x37},
 						},
 					},
 				},


### PR DESCRIPTION
### Summary
The mgmt api endpoint assumed image/gif content type. Instead try our best to detect it.

If the content type can't be determined then it defaults to application/octet-stream

### Testing
I tested by uploading gif and jpg buddy icons via pidgin and I'm able to fetch them from the api. PNG did not work for me, but it also didn't display in pidgin, so that format may not be supported.

Unit tests pass