### PR TITLE
Update ras.service to include missing API_PORT argument

### DIFF
--- a/config/ras.service
+++ b/config/ras.service
@@ -8,6 +8,7 @@ Group=ras
 Environment="ADMIN_PORT=5196"
 Environment="ALERT_PORT=5194"
 Environment="AUTH_PORT=5190"
+Environment="API_PORT=8080"
 Environment="BART_PORT=5195"
 Environment="BOS_PORT=5191"
 Environment="CHAT_NAV_PORT=5193"


### PR DESCRIPTION
Got an error about a missing environment variables for API_HOST while running through the systemd example, this adds it to the example service file.