### PR TITLE
Adding notes about FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Invoke-WebRequest -Uri http://localhost:8080/chat/room/public `
 Invoke-WebRequest -Uri http://localhost:8080/chat/room/public -Method Get
 ```
 
-### macOS / Linux
+### macOS / Linux / FreeBSD
 
 #### List Users
 

--- a/docs/ADDITIONAL_SETUP.md
+++ b/docs/ADDITIONAL_SETUP.md
@@ -33,7 +33,7 @@ keywords and keyword categories via the management API.
     -Body '{"name": "Music"}'
    ```
 
-   ###### macOS / Linux
+   ###### macOS / Linux / FreeBSD
 
     ```shell
     curl -d'{"name": "Programming Languages"}' http://localhost:8080/directory/category
@@ -51,7 +51,7 @@ keywords and keyword categories via the management API.
    Invoke-WebRequest -Uri "http://localhost:8080/directory/category" -Method GET
    ```
 
-   ###### macOS / Linux
+   ###### macOS / Linux / FreeBSD
 
     ```shell
     curl http://localhost:8080/directory/category
@@ -105,7 +105,7 @@ keywords and keyword categories via the management API.
       -Body '{"name": "Live, laugh, love!"}'
    ```
 
-   ###### macOS / Linux
+   ###### macOS / Linux / FreeBSD
 
     ```shell
     curl -d'{"category_id": 2, "name": "The Dictionary"}' http://localhost:8080/directory/keyword

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -4,7 +4,7 @@ This guide explains how to install and configure AIM clients for Retro AIM Serve
 
 ## Installation
 
-### Linux
+### Linux / FreeBSD
 
 Windows AIM versions 5.0-5.1.3036 run perfectly well on [Wine](https://www.winehq.org/). Here's how to set up AIM
 5.1.3036.


### PR DESCRIPTION
I've got the Retro AIM Server up and running on FreeBSD.

The instructions are almost identical to Linux, since Go is really OS agnostic.

This is just a start, and later I'd like to get a FreeBSD "ports" file/documentation setup to streamline this process on that side of things.