### PR TITLE
Close toCh on client disconnect

### DIFF
--- a/server/toc/server.go
+++ b/server/toc/server.go
@@ -205,8 +205,8 @@ func (rt Server) dispatchFLAP(ctx context.Context, conn net.Conn) error {
 	// messages to TOC client
 	toCh := make(chan []byte, 2)
 
-	// read in messages from client. when client disconnects, it closes fromCh.
-	go rt.readFromClient(ctx, fromCh, clientFlap)
+	// read in messages from client. when client disconnects, it closes fromCh and toCh.
+	go rt.readFromClient(ctx, fromCh, toCh, clientFlap)
 
 	g, gCtx := errgroup.WithContext(ctx)
 
@@ -309,8 +309,9 @@ func (rt Server) login(ctx context.Context, clientFlap *wire.FlapClient) (*state
 	return sessBOS, nil
 }
 
-func (rt Server) readFromClient(ctx context.Context, msgCh chan<- wire.FLAPFrame, clientFlap *wire.FlapClient) {
+func (rt Server) readFromClient(ctx context.Context, msgCh chan<- wire.FLAPFrame, toCh chan<- []byte, clientFlap *wire.FlapClient) {
 	defer close(msgCh)
+	defer close(toCh)
 
 	for {
 		clientFrame, err := clientFlap.ReceiveFLAP()


### PR DESCRIPTION
### Summary
Fixes issue #105

toCh was improperly being left open, ultimately causing the user session to remain active after the user disconnects.


### Testing
With this fix I can no longer reproduce the issue.

1. Signed onto Tik client
2. Removed myself from buddylist
3. Signed off 
4. Observed in session endpoint that the client session is now properly closed