### PR TITLE
replace ICQ Interests and Affiliations slices

### DIFF
--- a/foodgroup/icq.go
+++ b/foodgroup/icq.go
@@ -461,9 +461,11 @@ func (s ICQService) OfflineMsgReq(ctx context.Context, sess *state.Session, seq 
 }
 
 func (s ICQService) SetAffiliations(ctx context.Context, sess *state.Session, req wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations, seq uint16) error {
-	if len(req.PastAffiliations) != 3 || len(req.Affiliations) != 3 {
-		return fmt.Errorf("%w: expected 3 past affiliations and 3 affiliations", errICQBadRequest)
-	}
+	if req.PastAffiliations[0].Code == 0 || req.Affiliations[0].Code == 0 ||
+		req.PastAffiliations[1].Code == 0 || req.Affiliations[1].Code == 0 ||
+		req.PastAffiliations[2].Code == 0 || req.Affiliations[2].Code == 0 {
+		 return fmt.Errorf("%w: expected 3 past affiliations and 3 affiliations", errICQBadRequest)
+	 }
 	u := state.ICQAffiliations{
 		PastCode1:       req.PastAffiliations[0].Code,
 		PastKeyword1:    req.PastAffiliations[0].Keyword,
@@ -519,9 +521,10 @@ func (s ICQService) SetEmails(ctx context.Context, sess *state.Session, req wire
 }
 
 func (s ICQService) SetInterests(ctx context.Context, sess *state.Session, req wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests, seq uint16) error {
-	if len(req.Interests) != 4 {
-		return fmt.Errorf("%w: expected 4 interests", errICQBadRequest)
-	}
+    if req.Interests[0].Code == 0 || req.Interests[1].Code == 0 ||
+       req.Interests[2].Code == 0 || req.Interests[3].Code == 0 {
+        return fmt.Errorf("%w: expected exactly 4 interests", errICQBadRequest)
+    }
 	u := state.ICQInterests{
 		Code1:    req.Interests[0].Code,
 		Keyword1: req.Interests[0].Keyword,
@@ -656,7 +659,7 @@ func (s ICQService) affiliations(ctx context.Context, sess *state.Session, user 
 			ReqSubType: wire.ICQDBQueryMetaReplyAffiliations,
 			Success:    wire.ICQStatusCodeOK,
 			ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-				PastAffiliations: []struct {
+				PastAffiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -673,7 +676,7 @@ func (s ICQService) affiliations(ctx context.Context, sess *state.Session, user 
 						Keyword: user.ICQAffiliations.PastKeyword3,
 					},
 				},
-				Affiliations: []struct {
+				Affiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{

--- a/foodgroup/icq.go
+++ b/foodgroup/icq.go
@@ -461,11 +461,6 @@ func (s ICQService) OfflineMsgReq(ctx context.Context, sess *state.Session, seq 
 }
 
 func (s ICQService) SetAffiliations(ctx context.Context, sess *state.Session, req wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations, seq uint16) error {
-	if req.PastAffiliations[0].Code == 0 || req.Affiliations[0].Code == 0 ||
-		req.PastAffiliations[1].Code == 0 || req.Affiliations[1].Code == 0 ||
-		req.PastAffiliations[2].Code == 0 || req.Affiliations[2].Code == 0 {
-		 return fmt.Errorf("%w: expected 3 past affiliations and 3 affiliations", errICQBadRequest)
-	 }
 	u := state.ICQAffiliations{
 		PastCode1:       req.PastAffiliations[0].Code,
 		PastKeyword1:    req.PastAffiliations[0].Keyword,
@@ -521,10 +516,6 @@ func (s ICQService) SetEmails(ctx context.Context, sess *state.Session, req wire
 }
 
 func (s ICQService) SetInterests(ctx context.Context, sess *state.Session, req wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests, seq uint16) error {
-    if req.Interests[0].Code == 0 || req.Interests[1].Code == 0 ||
-       req.Interests[2].Code == 0 || req.Interests[3].Code == 0 {
-        return fmt.Errorf("%w: expected exactly 4 interests", errICQBadRequest)
-    }
 	u := state.ICQInterests{
 		Code1:    req.Interests[0].Code,
 		Keyword1: req.Interests[0].Keyword,

--- a/foodgroup/icq_test.go
+++ b/foodgroup/icq_test.go
@@ -1706,7 +1706,7 @@ func TestICQService_FullUserInfo(t *testing.T) {
 													Success:    wire.ICQStatusCodeOK,
 													ReqSubType: wire.ICQDBQueryMetaReplyAffiliations,
 													ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-														PastAffiliations: []struct {
+														PastAffiliations: [3]struct {
 															Code    uint16
 															Keyword string `oscar:"len_prefix=uint16,nullterm"`
 														}{
@@ -1723,7 +1723,7 @@ func TestICQService_FullUserInfo(t *testing.T) {
 																Keyword: "Previous Job",
 															},
 														},
-														Affiliations: []struct {
+														Affiliations: [3]struct {
 															Code    uint16
 															Keyword string `oscar:"len_prefix=uint16,nullterm"`
 														}{
@@ -1978,7 +1978,7 @@ func TestICQService_SetAffiliations(t *testing.T) {
 			seq:  1,
 			sess: newTestSession("100003", sessOptUIN(100003)),
 			req: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-				PastAffiliations: []struct {
+				PastAffiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -1995,7 +1995,7 @@ func TestICQService_SetAffiliations(t *testing.T) {
 						Keyword: "kw3",
 					},
 				},
-				Affiliations: []struct {
+				Affiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -2072,7 +2072,7 @@ func TestICQService_SetAffiliations(t *testing.T) {
 			seq:  1,
 			sess: newTestSession("100003", sessOptUIN(100003)),
 			req: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-				PastAffiliations: []struct {
+				PastAffiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -2081,7 +2081,7 @@ func TestICQService_SetAffiliations(t *testing.T) {
 						Keyword: "kw1",
 					},
 				},
-				Affiliations: []struct {
+				Affiliations: [3]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -2317,7 +2317,7 @@ func TestICQService_SetInterests(t *testing.T) {
 			seq:  1,
 			sess: newTestSession("100003", sessOptUIN(100003)),
 			req: wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests{
-				Interests: []struct {
+				Interests: [4]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{
@@ -2394,7 +2394,7 @@ func TestICQService_SetInterests(t *testing.T) {
 			seq:  1,
 			sess: newTestSession("100003", sessOptUIN(100003)),
 			req: wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests{
-				Interests: []struct {
+				Interests: [4]struct {
 					Code    uint16
 					Keyword string `oscar:"len_prefix=uint16,nullterm"`
 				}{

--- a/foodgroup/icq_test.go
+++ b/foodgroup/icq_test.go
@@ -2067,32 +2067,6 @@ func TestICQService_SetAffiliations(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "err: unexpected affiliations count",
-			seq:  1,
-			sess: newTestSession("100003", sessOptUIN(100003)),
-			req: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-				PastAffiliations: [3]struct {
-					Code    uint16
-					Keyword string `oscar:"len_prefix=uint16,nullterm"`
-				}{
-					{
-						Code:    1,
-						Keyword: "kw1",
-					},
-				},
-				Affiliations: [3]struct {
-					Code    uint16
-					Keyword string `oscar:"len_prefix=uint16,nullterm"`
-				}{
-					{
-						Code:    4,
-						Keyword: "kw4",
-					},
-				},
-			},
-			wantErr: errICQBadRequest,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2388,27 +2362,6 @@ func TestICQService_SetInterests(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "err: unexpected interest count",
-			seq:  1,
-			sess: newTestSession("100003", sessOptUIN(100003)),
-			req: wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests{
-				Interests: [4]struct {
-					Code    uint16
-					Keyword string `oscar:"len_prefix=uint16,nullterm"`
-				}{
-					{
-						Code:    1,
-						Keyword: "kw1",
-					},
-					{
-						Code:    2,
-						Keyword: "kw2",
-					},
-				},
-			},
-			wantErr: errICQBadRequest,
 		},
 	}
 	for _, tt := range tests {

--- a/server/oscar/handler/icq_test.go
+++ b/server/oscar/handler/icq_test.go
@@ -657,7 +657,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 									},
 									ReqSubType: wire.ICQDBQueryMetaReqSetInterests,
 									MetaRequest: wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests{
-										Interests: []struct {
+										Interests: [4]struct {
 											Code    uint16
 											Keyword string `oscar:"len_prefix=uint16,nullterm"`
 										}{
@@ -676,7 +676,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 			allMockParams: allMockParams{
 				setInterests: &mockParam{
 					req: wire.ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests{
-						Interests: []struct {
+						Interests: [4]struct {
 							Code    uint16
 							Keyword string `oscar:"len_prefix=uint16,nullterm"`
 						}{
@@ -703,7 +703,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 									},
 									ReqSubType: wire.ICQDBQueryMetaReqSetAffiliations,
 									MetaRequest: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-										PastAffiliations: []struct {
+										PastAffiliations: [3]struct {
 											Code    uint16
 											Keyword string `oscar:"len_prefix=uint16,nullterm"`
 										}{
@@ -711,7 +711,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 												Keyword: "a_past_affiliation",
 											},
 										},
-										Affiliations: []struct {
+										Affiliations: [3]struct {
 											Code    uint16
 											Keyword string `oscar:"len_prefix=uint16,nullterm"`
 										}{
@@ -730,7 +730,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 			allMockParams: allMockParams{
 				setAffiliations: &mockParam{
 					req: wire.ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations{
-						PastAffiliations: []struct {
+						PastAffiliations: [3]struct {
 							Code    uint16
 							Keyword string `oscar:"len_prefix=uint16,nullterm"`
 						}{
@@ -738,7 +738,7 @@ func TestICQHandler_DBQuery(t *testing.T) {
 								Keyword: "a_past_affiliation",
 							},
 						},
-						Affiliations: []struct {
+						Affiliations: [3]struct {
 							Code    uint16
 							Keyword string `oscar:"len_prefix=uint16,nullterm"`
 						}{

--- a/wire/snacs.go
+++ b/wire/snacs.go
@@ -1802,18 +1802,18 @@ type ICQ_0x07D0_0x0406_DBQueryMetaReqSetNotes struct {
 }
 
 type ICQ_0x07D0_0x0410_DBQueryMetaReqSetInterests struct {
-	Interests []struct {
+	Interests [4]struct {
 		Code    uint16
 		Keyword string `oscar:"len_prefix=uint16,nullterm"`
 	} `oscar:"count_prefix=uint8"`
 }
 
 type ICQ_0x07D0_0x041A_DBQueryMetaReqSetAffiliations struct {
-	PastAffiliations []struct {
+	PastAffiliations [3]struct {
 		Code    uint16
 		Keyword string `oscar:"len_prefix=uint16,nullterm"`
 	} `oscar:"count_prefix=uint8"`
-	Affiliations []struct {
+	Affiliations [3]struct {
 		Code    uint16
 		Keyword string `oscar:"len_prefix=uint16,nullterm"`
 	} `oscar:"count_prefix=uint8"`


### PR DESCRIPTION
addresses issue #110

note that the "unexpected count" tests assume that Code can never be equal to 0 and that Interests & Affiliations can never be blank; this is because Go zero's out the array when it's created, thus it is technically impossible to submit an unexpected count, since any Codes that are not explicitly set will be equal to 0, and any Interests or Affiliations that are not explicitly set will be equal to "". this sounds like desirable behavior, but i still wanted to make mention of it.