### PR TITLE
Persist database in the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN go build -o retro_aim_server ./cmd/server
 
 FROM alpine:latest
 
+VOLUME ./docker-data /vol
+
 WORKDIR /app
 
 COPY --from=builder /app/retro_aim_server /app/

--- a/config/ssl/settings.env
+++ b/config/ssl/settings.env
@@ -60,7 +60,7 @@ export API_LISTENER=127.0.0.1:8080
 
 # The path to the SQLite database file. The file and DB schema are auto-created
 # if they doesn't exist.
-export DB_PATH=oscar.sqlite
+export DB_PATH=/vol/oscar.sqlite
 
 # Disable password check and auto-create new users at login time. Useful for
 # quickly creating new accounts during development without having to register

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
       - "8080:8080"
     env_file:
       - ./config/ssl/settings.env
+    volumes:
+      - ./docker-data:/vol
 
   stunnel:
     image: ras-stunnel:5.75-openssl-1.0.2u


### PR DESCRIPTION
Mounts the `docker-data` directory in the root of the repository to `/vol` in the Docker container