### PR TITLE
fix hang when server startup fails mid-sequence

### DIFF
--- a/server/oscar/server.go
+++ b/server/oscar/server.go
@@ -68,8 +68,10 @@ func NewServer(
 type Server struct {
 	logger *slog.Logger
 
-	listenerCfg []config.Listener
-	listeners   []net.Listener
+	listenerCfg   []config.Listener
+	listeners     []net.Listener
+	listenerMu    sync.Mutex
+	listenersDone bool
 
 	connMu sync.Mutex
 	conns  map[net.Conn]struct{}
@@ -93,6 +95,11 @@ func (s *Server) ListenAndServe() error {
 			return fmt.Errorf("failed to listen on %s: %w", listenCfg.BOSListenAddress, err)
 		}
 
+		// Atomically append the listener, or bail out if Shutdown already ran.
+		if !s.tryAddListener(ln) {
+			return nil
+		}
+
 		args := []any{
 			"listen_address", listenCfg.BOSListenAddress,
 			"advertised_host_plain", listenCfg.BOSAdvertisedHostPlain,
@@ -102,7 +109,6 @@ func (s *Server) ListenAndServe() error {
 		}
 		s.logger.Info("starting server", args...)
 
-		s.listeners = append(s.listeners, ln)
 		s.listenWg.Add(1)
 		go s.acceptLoop(ln, listenCfg)
 	}
@@ -175,7 +181,23 @@ func (s *Server) handleConnection(ctx context.Context, conn net.Conn, listener c
 	}
 }
 
+// tryAddListener atomically appends ln to s.listeners if shutdown has not yet
+// started. If cleanup has already run, ln is closed and false is returned.
+func (s *Server) tryAddListener(ln net.Listener) bool {
+	s.listenerMu.Lock()
+	defer s.listenerMu.Unlock()
+	if s.listenersDone {
+		_ = ln.Close()
+		return false
+	}
+	s.listeners = append(s.listeners, ln)
+	return true
+}
+
 func (s *Server) cleanupListeners() {
+	s.listenerMu.Lock()
+	defer s.listenerMu.Unlock()
+	s.listenersDone = true
 	for _, ln := range s.listeners {
 		_ = ln.Close()
 	}

--- a/server/oscar/server_test.go
+++ b/server/oscar/server_test.go
@@ -21,6 +21,30 @@ import (
 	"github.com/mk6i/open-oscar-server/wire"
 )
 
+func TestServer_ListenAndServe_ShutdownBeforeStart(t *testing.T) {
+	cfg := []config.Listener{
+		{BOSListenAddress: ":0", BOSAdvertisedHostPlain: "localhost"},
+	}
+
+	server := NewServer(
+		nil, nil, nil, nil,
+		slog.Default(),
+		nil, nil, nil,
+		wire.DefaultSNACRateLimits(),
+		nil, cfg,
+		func(ctx context.Context, instance *state.SessionInstance) error { return nil },
+		func(ctx context.Context, instance *state.SessionInstance) {},
+	)
+
+	// simulate Shutdown running before ListenAndServe is scheduled
+	server.cleanupListeners()
+	server.shutdownCancel()
+
+	err := server.ListenAndServe()
+	assert.NoError(t, err)
+	assert.Empty(t, server.listeners)
+}
+
 func TestServer_ListenAndServeAndShutdown(t *testing.T) {
 	var mu sync.Mutex
 	var received []string

--- a/server/toc/server.go
+++ b/server/toc/server.go
@@ -168,9 +168,11 @@ type Server struct {
 	recalcWarning      func(ctx context.Context, instance *state.SessionInstance) error
 	lowerWarnLevel     func(ctx context.Context, instance *state.SessionInstance)
 
-	listenerCfg []string
-	listeners   []net.Listener
-	servers     []*http.Server
+	listenerCfg   []string
+	listeners     []net.Listener
+	listenerMu    sync.Mutex
+	listenersDone bool
+	servers       []*http.Server
 
 	connMu sync.Mutex
 	conns  map[net.Conn]struct{}
@@ -193,9 +195,13 @@ func (s *Server) ListenAndServe() error {
 			return fmt.Errorf("unable to start TOC server: %w", err)
 		}
 
+		// Atomically append the listener, or bail out if Shutdown already ran.
+		if !s.tryAddListener(ln) {
+			break
+		}
+
 		s.logger.InfoContext(ctx, "starting server", "listen_host", cfg)
 
-		s.listeners = append(s.listeners, ln)
 		s.listenWg.Add(1)
 
 		httpCh := make(chan net.Conn)
@@ -248,7 +254,23 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// tryAddListener atomically appends ln to s.listeners if shutdown has not yet
+// started. If cleanup has already run, ln is closed and false is returned.
+func (s *Server) tryAddListener(ln net.Listener) bool {
+	s.listenerMu.Lock()
+	defer s.listenerMu.Unlock()
+	if s.listenersDone {
+		_ = ln.Close()
+		return false
+	}
+	s.listeners = append(s.listeners, ln)
+	return true
+}
+
 func (s *Server) cleanupListeners() {
+	s.listenerMu.Lock()
+	defer s.listenerMu.Unlock()
+	s.listenersDone = true
 	for _, ln := range s.listeners {
 		_ = ln.Close()
 	}

--- a/server/toc/server_test.go
+++ b/server/toc/server_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"sync"
 	"testing"
 
@@ -13,6 +14,45 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+// ensure ListenAndServe returns immediately when shutdownCtx is already cancelled,
+// simulating Shutdown being called before the goroutine is scheduled
+func TestServer_ListenAndServe_ShutdownBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	s := &Server{
+		shutdownCtx:    ctx,
+		shutdownCancel: cancel,
+		listenerCfg:    []string{":0"},
+	}
+	// simulate Shutdown running before ListenAndServe is scheduled
+	s.cleanupListeners()
+	cancel()
+
+	err := s.ListenAndServe()
+	assert.NoError(t, err)
+	assert.Empty(t, s.listeners)
+}
+
+// ensure tryAddListener appends the listener and returns true when shutdown has
+// not yet started
+func TestServer_tryAddListener(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := &Server{
+		shutdownCtx:    ctx,
+		shutdownCancel: cancel,
+	}
+
+	ln, err := net.Listen("tcp", ":0")
+	assert.NoError(t, err)
+
+	assert.True(t, s.tryAddListener(ln))
+	assert.Len(t, s.listeners, 1)
+
+	s.cleanupListeners()
+}
 
 // ensure correct behavior during global context cancellation (server shutdown)
 func TestServer_handleTOCRequest_serverShutdown(t *testing.T) {


### PR DESCRIPTION
### Summary
I noticed that with an invalid listener config (such as entering the wrong bind IP address), that sometimes the server would immediately print shutdown messages and hang until a kill -9 was used.

After analyzing the issue with Claude, it was determined to be a race condition. If a bind failure occurs, we start firing the Shutdown sequence on the TOC and OSCAR servers, but it's possible that ListenAndServe has not added the listener yet. 

>If a server's ListenAndServe then runs after its Shutdown has already been called, the new listener never gets added to s.listeners before cleanupListeners ran, so it is never closed and acceptLoop blocks forever.

Using a mutex prevents the race occurring. All of the server listeners will be appended before cleanup runs.

### Testing
I setup my config using a listen address of 1.0.0.0. After restarting oos several times, I reproduce the hang.
```
export OSCAR_LISTENERS=LAN1://1.0.0.0:5190,LAN2://192.168.77.1:5190

./ras-toc2-mac
Successfully loaded config file (settings.env)
time=2026-03-19T19:45:14.768-04:00 level=DEBUG msg="no kerberos listeners defined" svc=Kerberos
time=2026-03-19T19:45:14.768-04:00 level=DEBUG msg="Initiating graceful shutdown..." svc=OSCAR
time=2026-03-19T19:45:14.768-04:00 level=INFO msg="shutdown complete" svc=OSCAR
time=2026-03-19T19:45:14.768-04:00 level=INFO msg="shutdown complete" svc=API
time=2026-03-19T19:45:14.768-04:00 level=DEBUG msg="Initiating graceful shutdown..." svc=TOC
time=2026-03-19T19:45:14.768-04:00 level=INFO msg="starting server" svc=API addr=127.0.0.1:8080
time=2026-03-19T19:45:14.769-04:00 level=INFO msg="shutdown complete" svc=TOC
time=2026-03-19T19:45:14.769-04:00 level=INFO msg="starting server" svc=TOC listen_host=0.0.0.0:9898


^C^C^C[1]    30164 killed     ./ras-toc2-mac
```
---
With the fix in place, I restarted oos several times and can no longer reproduce the hang.

Unit tests were added to exercise the change. If I undo the bug fix and run the new unit tests (with a timeout) they fail
```
go test ./server/oscar/ ./server/toc/ -run "TestServer_ListenAndServe_ShutdownBeforeStart" -v -timeout 15s 
=== RUN   TestServer_ListenAndServe_ShutdownBeforeStart
2026/03/19 20:59:32 INFO starting server listen_address=:0 advertised_host_plain=localhost
panic: test timed out after 15s
        running tests:
                TestServer_ListenAndServe_ShutdownBeforeStart (15s)

goroutine 25 [running]:
testing.(*M).startAlarm.func1()
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:2682 +0x2b0
created by time.goFunc
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/time/sleep.go:215 +0x38

goroutine 1 [chan receive]:
testing.(*T).Run(0x14000003c00, {0x1049bef44?, 0x1400002fb38?}, 0x104bcfcb8)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:2005 +0x378
testing.runTests.func1(0x14000003c00)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:2477 +0x38
testing.tRunner(0x14000003c00, 0x1400002fc68)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1934 +0xc8
testing.runTests(0x1400000e210, {0x1050b6800, 0x50, 0x50}, {0x1400038fe60?, 0x7?, 0x1050bc3e0?})
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:2475 +0x3b8
testing.(*M).Run(0x140000d6f00)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:2337 +0x530
main.main()
        _testmain.go:203 +0x80

goroutine 23 [chan receive]:
github.com/mk6i/open-oscar-server/server/oscar.(*Server).ListenAndServe(0x1400015c480)
        /Users/josh/code/open-oscar-server/server/oscar/server.go:110 +0x358
github.com/mk6i/open-oscar-server/server/oscar.TestServer_ListenAndServe_ShutdownBeforeStart(0x14000003dc0)
        /Users/josh/code/open-oscar-server/server/oscar/server_test.go:43 +0x140
testing.tRunner(0x14000003dc0, 0x104bcfcb8)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1997 +0x364

goroutine 24 [IO wait]:
internal/poll.runtime_pollWait(0x105499200, 0x72)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/netpoll.go:351 +0xa0
internal/poll.(*pollDesc).wait(0x1400018c880?, 0x105056ee0?, 0x0)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:84 +0x28
internal/poll.(*pollDesc).waitRead(...)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Accept(0x1400018c880)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_unix.go:613 +0x21c
net.(*netFD).accept(0x1400018c880)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/net/fd_unix.go:161 +0x28
net.(*TCPListener).accept(0x140000fab00)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/net/tcpsock_posix.go:159 +0x24
net.(*TCPListener).Accept(0x140000fab00)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/net/tcpsock.go:380 +0x2c
github.com/mk6i/open-oscar-server/server/oscar.(*Server).acceptLoop(0x1400015c480, {0x104bd8b80, 0x140000fab00}, {{0x1049a29de, 0x2}, {0x1049a706c, 0x9}, {0x0, 0x0}, {0x0, ...}, ...})
        /Users/josh/code/open-oscar-server/server/oscar/server.go:143 +0x88
created by github.com/mk6i/open-oscar-server/server/oscar.(*Server).ListenAndServe in goroutine 23
        /Users/josh/code/open-oscar-server/server/oscar/server.go:107 +0x60
FAIL    github.com/mk6i/open-oscar-server/server/oscar  15.259s
=== RUN   TestServer_ListenAndServe_ShutdownBeforeStart
--- FAIL: TestServer_ListenAndServe_ShutdownBeforeStart (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1045ec630]

goroutine 7 [running]:
testing.tRunner.func1.2({0x104cf4520, 0x10534a940})
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1872 +0x190
testing.tRunner.func1()
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1875 +0x31c
panic({0x104cf4520?, 0x10534a940?})
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/panic.go:783 +0x120
log/slog.(*Logger).Handler(...)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/log/slog/logger.go:121
log/slog.(*Logger).Enabled(0x140000a4ae8?, {0x104dc1bb0?, 0x140000f8af0?}, 0x104dc1a28?)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/log/slog/logger.go:168 +0x20
log/slog.(*Logger).log(0x0, {0x104dc1bb0?, 0x140000f8af0?}, 0x0, {0x104afa640, 0xf}, {0x1400020fea8, 0x2, 0x2})
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/log/slog/logger.go:244 +0x6c
log/slog.(*Logger).InfoContext(...)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/log/slog/logger.go:214
github.com/mk6i/open-oscar-server/server/toc.(*Server).ListenAndServe(0x14000208000)
        /Users/josh/code/open-oscar-server/server/toc/server.go:196 +0x160
github.com/mk6i/open-oscar-server/server/toc.TestServer_ListenAndServe_ShutdownBeforeStart(0x14000485180)
        /Users/josh/code/open-oscar-server/server/toc/server_test.go:31 +0x134
testing.tRunner(0x14000485180, 0x104db4568)
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1934 +0xc8
created by testing.(*T).Run in goroutine 1
        /opt/homebrew/Cellar/go/1.25.5/libexec/src/testing/testing.go:1997 +0x364
FAIL    github.com/mk6i/open-oscar-server/server/toc    0.463s
FAIL
```
---
With a properly configured settings.env (valid listener IP), oos starts up successfully and I'm able to connect to the server using a windows AIM client.