### PR TITLE
webapi: support vintage ICQ clients (Jimm/QIP) for IM

### DIFF
--- a/state/webapi_session.go
+++ b/state/webapi_session.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -139,11 +140,38 @@ func (s *WebAPISession) handleIncomingIM(msg wire.SNACMessage) {
 		return
 	}
 
-	// Extract message text from TLV data
+	// Extract message text from TLV data.
+	// Channel 1 (standard AIM/ICQ text): text is in TLV(0x0002) as a fragment
+	// list. Channel 2 (ICQ advanced/Type-2, used by Jimm/QIP/JOscarLib bots):
+	// text is buried inside TLV(0x0005)→TLV(0x2711). Try Channel 1 first,
+	// then fall back to Channel 2 parsing for vintage ICQ clients.
 	var messageText string
 	if msgData, hasMsg := body.Bytes(wire.ICBMTLVAOLIMData); hasMsg {
 		if text, err := wire.UnmarshalICBMMessageText(msgData); err == nil {
 			messageText = text
+		}
+	}
+
+	// Channel 2 fallback: parse TLV(0x0005) → nested TLV(0x2711) → extract
+	// text. This is the format used by vintage ICQ clients (Jimm, QIP) and
+	// Java bots (JOscarLib). Without this, messages from these clients are
+	// silently dropped (text="" → early return).
+	if messageText == "" && body.ChannelID == wire.ICBMChannelRendezvous {
+		if tlv5Data, hasTlv5 := body.Bytes(wire.ICBMTLVData); hasTlv5 {
+			// TLV 0x0005 value starts with 26 bytes of non-TLV data:
+			// ack type(2) + cookie/time(4) + message id(4) + capability(16).
+			// Skip them, then parse the rest as a nested TLV list containing
+			// TLV 0x000A, TLV 0x000F, and TLV 0x2711 (service data).
+			if len(tlv5Data) > 26 {
+				var tlv5 wire.TLVRestBlock
+				if err := wire.UnmarshalBE(&tlv5, bytes.NewReader(tlv5Data[26:])); err == nil {
+					if svcData, has2711 := tlv5.Bytes(wire.ICBMRdvTLVTagsSvcData); has2711 {
+						if text, err := wire.UnmarshalICBMCh2MessageText(svcData); err == nil {
+							messageText = text
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/wire/snacs.go
+++ b/wire/snacs.go
@@ -905,12 +905,24 @@ type SNAC_0x04_0x07_ICBMChannelMsgToClient struct {
 }
 
 // ICBMFragmentList creates an ICBM fragment list for an instant message
-// payload.
+// payload. Non-ASCII text (e.g. Cyrillic) is encoded as UCS-2 BE with
+// charset=0x0002 so that vintage ICQ clients and Java bots (JOscarLib)
+// decode it correctly. Pure ASCII text uses charset=0x0000 with raw bytes.
 func ICBMFragmentList(text string) ([]ICBMCh1Fragment, error) {
+	var charset uint16
+	var textBytes []byte
+	if isASCII(text) {
+		charset = ICBMMessageEncodingASCII
+		textBytes = []byte(text)
+	} else {
+		charset = ICBMMessageEncodingUnicode
+		textBytes = encodeUCS2BE(text)
+	}
+
 	msg := ICBMCh1Message{
-		Charset:  ICBMMessageEncodingASCII,
+		Charset:  charset,
 		Language: 0, // not clear what this means, but it works
-		Text:     []byte(text),
+		Text:     textBytes,
 	}
 	msgBuf := bytes.Buffer{}
 	if err := MarshalBE(msg, &msgBuf); err != nil {
@@ -929,6 +941,31 @@ func ICBMFragmentList(text string) ([]ICBMCh1Fragment, error) {
 			Payload: msgBuf.Bytes(),
 		},
 	}, nil
+}
+
+// isASCII returns true if all runes in s fit in the 7-bit ASCII range (0x00-0x7F).
+func isASCII(s string) bool {
+	for _, r := range s {
+		if r > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+// encodeUCS2BE encodes a Go UTF-8 string into UCS-2 big-endian bytes (the
+// inverse of decodeUCS2BE). This is the charset=0x0002 format that ICQ clients
+// expect for non-ASCII text. Characters outside the BMP are replaced with U+FFFD.
+func encodeUCS2BE(s string) []byte {
+	runes := []rune(s)
+	buf := make([]byte, len(runes)*2)
+	for i, r := range runes {
+		if r > 0xFFFF {
+			r = 0xFFFD
+		}
+		binary.BigEndian.PutUint16(buf[i*2:], uint16(r))
+	}
+	return buf
 }
 
 // UnmarshalICBMMessageText extracts message text from an ICBM fragment list.
@@ -2893,3 +2930,124 @@ const (
 	TOC2ErrorChatJoinSubErrorRated    = "48"
 	TOC2ErrorChatJoinSubErrorEjected  = "74"
 )
+
+// UnmarshalICBMCh2MessageText extracts message text from an ICQ Channel 2
+// (Type-2 advanced) TLV 0x2711 service data blob. Vintage ICQ clients (Jimm,
+// QIP) and Java bots (JOscarLib) send messages via Channel 2, where the text
+// is buried inside a complex binary structure rather than the simple Channel 1
+// TLV(0x0002) fragment list.
+//
+// The 0x2711 blob layout (per ICQ advanced message format):
+//
+//	[2]  TCP version
+//	[16] capability GUID
+//	[2]  0x0003 (flags)
+//	[1]  0x03
+//	[1]  0x00 (message flag: normal)
+//	[2]  message sequence (LE)
+//	[2]  len2 (LE)
+//	[2]  message sequence (LE)
+//	[13] unknown
+//	[1]  message type (0x01 = normal)
+//	[1]  message flag (0x01)
+//	[2]  0x0000
+//	[2]  0x0101 ← marker: text follows
+//	[1]  0x00
+//	[2]  text length (LE)
+//	[N]  text bytes (windows-1251 or UCS-2 BE)
+//	[1]  0x00 (null terminator)
+//	[4]  foreground color
+//	[4]  background color
+//
+// We skip the 43-byte fixed header, look for the 0x0101 marker, read the LE
+// length, and decode the text. The charset is usually windows-1251 for ICQ
+// clients; UCS-2 BE is handled when the charset codepage field indicates
+// Unicode.
+func UnmarshalICBMCh2MessageText(data []byte) (string, error) {
+	// Scan for the 0x0000 0x0101 marker — the text section always follows
+	// this pattern. Using a scan instead of a fixed offset because different
+	// ICQ clients (Jimm, QIP, JOscarLib) have slightly different TLV 0x2711
+	// header sizes.
+	markerIdx := -1
+	for i := 0; i+5 < len(data); i++ {
+		if data[i] == 0x00 && data[i+1] == 0x00 &&
+			data[i+2] == 0x01 && data[i+3] == 0x01 {
+			markerIdx = i + 4
+			break
+		}
+	}
+	if markerIdx < 0 {
+		return "", fmt.Errorf("ch2: 0x0101 marker not found in %d bytes", len(data))
+	}
+
+	// After 0x0101:
+	//   [1] charset (0x00 = cp1251, 0x02 = UCS-2 BE)
+	//   [2] message length (LE)
+	//   [N] message bytes
+	if markerIdx+3 > len(data) {
+		return "", fmt.Errorf("ch2: truncated after marker at %d", markerIdx)
+	}
+	charset := data[markerIdx]
+	msgLen := int(binary.LittleEndian.Uint16(data[markerIdx+1 : markerIdx+3]))
+	pos := markerIdx + 3
+	if pos+msgLen > len(data) {
+		return "", fmt.Errorf("ch2: truncated text (need %d, have %d)", msgLen, len(data)-pos)
+	}
+	msgBytes := data[pos : pos+msgLen]
+
+	if charset == 0x02 {
+		return decodeUCS2BE(msgBytes), nil
+	}
+	return decodeCP1251(msgBytes), nil
+}
+
+// decodeCP1251 converts windows-1251 (CP-1251) encoded bytes to a UTF-8 string.
+// This avoids pulling in golang.org/x/text/encoding/charmap for a single
+// legacy codepage. The 0x00-0x7F range is ASCII (identical in UTF-8); only
+// 0x80-0xFF need mapping.
+func decodeCP1251(b []byte) string {
+	var sb strings.Builder
+	sb.Grow(len(b))
+	for _, c := range b {
+		sb.WriteRune(cp1251Table[c])
+	}
+	return sb.String()
+}
+
+// cp1251Table maps each byte value 0x00-0xFF to its Unicode rune as encoded
+// by Windows-1251. Entries 0x00-0x7F are identity (ASCII). Entries 0x80-0xFF
+// are the Windows-1251 upper half.
+var cp1251Table = [256]rune{
+	0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, // 00-07
+	0x0008, 0x0009, 0x000A, 0x000B, 0x000C, 0x000D, 0x000E, 0x000F, // 08-0F
+	0x0010, 0x0011, 0x0012, 0x0013, 0x0014, 0x0015, 0x0016, 0x0017, // 10-17
+	0x0018, 0x0019, 0x001A, 0x001B, 0x001C, 0x001D, 0x001E, 0x001F, // 18-1F
+	0x0020, 0x0021, 0x0022, 0x0023, 0x0024, 0x0025, 0x0026, 0x0027, // 20-27
+	0x0028, 0x0029, 0x002A, 0x002B, 0x002C, 0x002D, 0x002E, 0x002F, // 28-2F
+	0x0030, 0x0031, 0x0032, 0x0033, 0x0034, 0x0035, 0x0036, 0x0037, // 30-37
+	0x0038, 0x0039, 0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F, // 38-3F
+	0x0040, 0x0041, 0x0042, 0x0043, 0x0044, 0x0045, 0x0046, 0x0047, // 40-47
+	0x0048, 0x0049, 0x004A, 0x004B, 0x004C, 0x004D, 0x004E, 0x004F, // 48-4F
+	0x0050, 0x0051, 0x0052, 0x0053, 0x0054, 0x0055, 0x0056, 0x0057, // 50-57
+	0x0058, 0x0059, 0x005A, 0x005B, 0x005C, 0x005D, 0x005E, 0x005F, // 58-5F
+	0x0060, 0x0061, 0x0062, 0x0063, 0x0064, 0x0065, 0x0066, 0x0067, // 60-67
+	0x0068, 0x0069, 0x006A, 0x006B, 0x006C, 0x006D, 0x006E, 0x006F, // 68-6F
+	0x0070, 0x0071, 0x0072, 0x0073, 0x0074, 0x0075, 0x0076, 0x0077, // 70-77
+	0x0078, 0x0079, 0x007A, 0x007B, 0x007C, 0x007D, 0x007E, 0x007F, // 78-7F
+	0x0402, 0x0403, 0x201A, 0x0453, 0x201E, 0x2026, 0x2020, 0x2021, // 80-87
+	0x20AC, 0x2030, 0x0409, 0x2039, 0x040A, 0x040C, 0x040B, 0x040F, // 88-8F
+	0x0452, 0x2018, 0x2019, 0x201C, 0x201D, 0x2022, 0x2013, 0x2014, // 90-97
+	0x007F, 0x2122, 0x0459, 0x203A, 0x045A, 0x045C, 0x045B, 0x045F, // 98-9F
+	0x00A0, 0x040E, 0x045E, 0x0408, 0x00A4, 0x0490, 0x00A6, 0x00A7, // A0-A7
+	0x0401, 0x00A9, 0x0404, 0x00AB, 0x00AC, 0x00AD, 0x00AE, 0x0407, // A8-AF
+	0x00B0, 0x00B1, 0x0406, 0x0456, 0x0491, 0x00B5, 0x00B6, 0x00B7, // B0-B7
+	0x0451, 0x2116, 0x0454, 0x00BB, 0x0458, 0x0405, 0x0455, 0x0457, // B8-BF
+	0x0410, 0x0411, 0x0412, 0x0413, 0x0414, 0x0415, 0x0416, 0x0417, // C0-C7
+	0x0418, 0x0419, 0x041A, 0x041B, 0x041C, 0x041D, 0x041E, 0x041F, // C8-CF
+	0x0420, 0x0421, 0x0422, 0x0423, 0x0424, 0x0425, 0x0426, 0x0427, // D0-D7
+	0x0428, 0x0429, 0x042A, 0x042B, 0x042C, 0x042D, 0x042E, 0x042F, // D8-DF
+	0x0430, 0x0431, 0x0432, 0x0433, 0x0434, 0x0435, 0x0436, 0x0437, // E0-E7
+	0x0438, 0x0439, 0x043A, 0x043B, 0x043C, 0x043D, 0x043E, 0x043F, // E8-EF
+	0x0440, 0x0441, 0x0442, 0x0443, 0x0444, 0x0445, 0x0446, 0x0447, // F0-F7
+	0x0448, 0x0449, 0x044A, 0x044B, 0x044C, 0x044D, 0x044E, 0x044F, // F8-FF
+}


### PR DESCRIPTION
- ICBMFragmentList now encodes non-ASCII text as UCS-2 BE (charset=0x0002) so Jimm/QIP/JOscarLib decode Cyrillic correctly; pure ASCII keeps charset=0x0000 with raw bytes.
- Add UnmarshalICBMCh2MessageText to parse text from ICQ Channel 2 (Type-2 advanced) TLV 0x2711 service data, used by Jimm/QIP/JOscarLib.
- Add self-contained CP-1251 decoder (no golang.org/x/text dependency).
- WebAPISession.handleIncomingIM: fall back to Channel 2 parsing when Channel 1 yields no text, so messages from these clients are not silently dropped.