### PR TITLE
fix TOC sign-on arrival not broadcast for buddy-less sessions

### DIFF
--- a/server/toc/cmd_client.go
+++ b/server/toc/cmd_client.go
@@ -1238,6 +1238,11 @@ func (s OSCARProxy) InitDone(ctx context.Context, instance *state.SessionInstanc
 	if errMsg, isLimited := s.checkRateLimit(ctx, instance, wire.OService, wire.OServiceClientOnline); isLimited {
 		return errMsg
 	}
+	// Per the TiK docs above, the buddy list precedes toc_init_done, so the
+	// contact list is fully submitted by now — even when the client sent no
+	// toc_add_buddy at all. Without this, ClientOnline skips the arrival
+	// broadcast for buddy-less sessions and watchers never see them sign on.
+	instance.SetContactsInit()
 	if err := s.OServiceService.ClientOnline(ctx, wire.BOS, wire.SNAC_0x01_0x02_OServiceClientOnline{}, instance); err != nil {
 		return s.runtimeErr(ctx, fmt.Errorf("OServiceServiceBOS.ClientOnliney: %w", err))
 	}

--- a/server/toc/cmd_client_test.go
+++ b/server/toc/cmd_client_test.go
@@ -3004,6 +3004,9 @@ func TestOSCARProxy_RecvClientCmd_InitDone(t *testing.T) {
 			msg := svc.RecvClientCmd(ctx, tc.me, nil, tc.givenCmd, nil, nil)
 
 			assert.Equal(t, tc.wantMsg, msg)
+			// toc_init_done marks the contact list submitted (even if empty)
+			// so that ClientOnline broadcasts the arrival to watchers.
+			assert.True(t, tc.me.ContactsInit())
 		})
 	}
 }


### PR DESCRIPTION
Fixes #195.

Since 17fd76b, `ClientOnline` defers the initial arrival broadcast until the session's contact list is initialized (`ContactsInit`), with compensating broadcasts in `FeedbagService.Use` and client-side `AddBuddies`. A TOC session that never sends `toc_add_buddy` hits neither path, so its arrival is never announced to OSCAR watchers — the session appears offline until it blips away state (the workaround from the issue) or the watcher re-logs. TiK is unaffected because it submits its buddy list before `toc_init_done`, which is also why the issue didn't reproduce there.

Per the TiK docs (quoted in `InitDone`'s doc comment), TOC clients send their buddy list before `toc_init_done` — so init-done is the point at which the contact list, possibly empty, is fully submitted. This change marks `ContactsInit` there. Orderings checked: TiK-style buddies-before (unchanged — idempotent set, single broadcast from `ClientOnline`), buddies-after (unchanged — `AddBuddies`' broadcast is filtered to the added buddies), never-buddies (fixed). OSCAR/ICQ clients are untouched; the change is TOC-only.

Verified live against an AIM 5.x client watching a buddy-less TOC session (the repro script from #195): on v0.24.0 the arrival is never delivered; with this patch the buddy appears at sign-on and departs at sign-off, no away-blip needed. Regression assertion added to the `InitDone` test; `go test -race ./...`, `gofmt -s`, `go vet` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
