### PR TITLE
Add mobile/wireless client detection

### DIFF
--- a/foodgroup/auth.go
+++ b/foodgroup/auth.go
@@ -153,8 +153,14 @@ func (s AuthService) RegisterBOSSession(ctx context.Context, authCookie state.Se
 
 	sess.SetKerberosAuth(authCookie.KerberosAuth == 1)
 
-	// set string containing OSCAR client name and version
-	sess.SetClientID(authCookie.ClientID)
+	// record the client identity reported at login
+	sess.SetClientInfo(state.ClientInfo{
+		ID:        authCookie.ClientID,
+		IDNum:     authCookie.ClientIDNum,
+		MajorVer:  authCookie.MajorVer,
+		MinorVer:  authCookie.MinorVer,
+		LesserVer: authCookie.LesserVer,
+	})
 	sess.Session().SetOfflineMsgCount(u.OfflineMsgCount)
 
 	if _, alreadySet := sess.Session().BuddyIcon(); !alreadySet {
@@ -420,6 +426,10 @@ func (s AuthService) KerberosLogin(ctx context.Context, inBody wire.SNAC_0x050C_
 // loginProperties represents the properties sent by the client at login.
 type loginProperties struct {
 	clientID                string
+	clientIDNum             uint16
+	majorVer                uint16
+	minorVer                uint16
+	lesserVer               uint16
 	isBUCPAuth              bool
 	isFLAPAuth              bool
 	isFLAPJavaAuth          bool
@@ -446,6 +456,18 @@ func (l *loginProperties) fromTLV(list wire.TLVList) error {
 	// extract client name and version
 	if clientID, found := list.String(wire.LoginTLVTagsClientIdentity); found {
 		l.clientID = clientID
+	}
+	if clientIDNum, found := list.Uint16BE(wire.LoginTLVTagsClientIDNumber); found {
+		l.clientIDNum = clientIDNum
+	}
+	if majorVer, found := list.Uint16BE(wire.LoginTLVTagsMajorVersion); found {
+		l.majorVer = majorVer
+	}
+	if minorVer, found := list.Uint16BE(wire.LoginTLVTagsMinorVersion); found {
+		l.minorVer = minorVer
+	}
+	if lesserVer, found := list.Uint16BE(wire.LoginTLVTagsLesserVersion); found {
+		l.lesserVer = lesserVer
 	}
 
 	// get the password from the appropriate TLV. older clients have a
@@ -629,6 +651,10 @@ func (s AuthService) loginSuccessResponse(ctx context.Context, props loginProper
 		ScreenName:    props.screenName,
 		ClientID:      props.clientID,
 		MultiConnFlag: props.multiConnFlag,
+		ClientIDNum:   props.clientIDNum,
+		MajorVer:      props.majorVer,
+		MinorVer:      props.minorVer,
+		LesserVer:     props.lesserVer,
 	}
 	if props.isKerberosPlaintextAuth || props.isKerberosRoastedAuth {
 		loginCookie.KerberosAuth = 1

--- a/foodgroup/auth_test.go
+++ b/foodgroup/auth_test.go
@@ -864,6 +864,76 @@ func TestAuthService_BUCPLoginRequest(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "mobile client version TLVs parsed, login OK",
+			advertisedHost: "127.0.0.1:5190",
+			inputSNAC: wire.SNAC_0x17_0x02_BUCPLoginRequest{
+				TLVRestBlock: wire.TLVRestBlock{
+					TLVList: wire.TLVList{
+						wire.NewTLVBE(wire.LoginTLVTagsScreenName, user.DisplayScreenName),
+						wire.NewTLVBE(wire.LoginTLVTagsPasswordHash, user.StrongMD5Pass),
+						wire.NewTLVBE(wire.LoginTLVTagsClientIDNumber, uint16(4)),
+						wire.NewTLVBE(wire.LoginTLVTagsMajorVersion, uint16(1)),
+						wire.NewTLVBE(wire.LoginTLVTagsMinorVersion, uint16(75)),
+						wire.NewTLVBE(wire.LoginTLVTagsLesserVersion, uint16(0)),
+						wire.NewTLVBE(wire.LoginTLVTagsMultiConnFlags, wire.MultiConnFlagsRecentClient),
+					},
+				},
+			},
+			mockParams: mockParams{
+				userManagerParams: userManagerParams{
+					getUserParams: getUserParams{
+						{
+							screenName: user.IdentScreenName,
+							result:     &user,
+						},
+					},
+				},
+				cookieBakerParams: cookieBakerParams{
+					cookieIssueParams: cookieIssueParams{
+						{
+							dataIn: func() []byte {
+								loginCookie := state.ServerCookie{
+									ScreenName:    user.DisplayScreenName,
+									MultiConnFlag: uint8(wire.MultiConnFlagsRecentClient),
+									ClientIDNum:   4,
+									MajorVer:      1,
+									MinorVer:      75,
+								}
+								buf := &bytes.Buffer{}
+								assert.NoError(t, wire.MarshalBE(loginCookie, buf))
+								return buf.Bytes()
+							}(),
+							cookieOut: []byte("the-cookie"),
+						},
+					},
+				},
+				sessionRetrieverParams: sessionRetrieverParams{
+					retrieveSessionParams: retrieveSessionParams{
+						{
+							screenName: user.IdentScreenName,
+							result:     nil,
+						},
+					},
+				},
+			},
+			expectOutput: wire.SNACMessage{
+				Frame: wire.SNACFrame{
+					FoodGroup: wire.BUCP,
+					SubGroup:  wire.BUCPLoginResponse,
+				},
+				Body: wire.SNAC_0x17_0x03_BUCPLoginResponse{
+					TLVRestBlock: wire.TLVRestBlock{
+						TLVList: wire.TLVList{
+							wire.NewTLVBE(wire.LoginTLVTagsScreenName, user.DisplayScreenName),
+							wire.NewTLVBE(wire.LoginTLVTagsReconnectHere, "127.0.0.1:5190"),
+							wire.NewTLVBE(wire.LoginTLVTagsAuthorizationCookie, []byte("the-cookie")),
+							wire.NewTLVBE(wire.OServiceTLVTagsSSLState, uint8(0x00)),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -2125,6 +2195,68 @@ func TestAuthService_RegisterBOSSession(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			// verifies that client version TLVs (0x0016-0x0019), which are only
+			// present at auth-stage login, survive the round trip through the
+			// auth cookie and land correctly on the session instance
+			name: "client identity carried through auth cookie onto session instance",
+			cookie: state.ServerCookie{
+				ScreenName:  screenName,
+				ClientID:    "AOL Instant Messenger, version 5.2.3255/WIN32",
+				ClientIDNum: 4,
+				MajorVer:    1,
+				MinorVer:    75,
+				LesserVer:   9,
+			},
+			mockParams: mockParams{
+				sessionRegistryParams: sessionRegistryParams{
+					addSessionParams: addSessionParams{
+						{
+							screenName:  screenName,
+							doMultiSess: false,
+							result:      newTestInstance(screenName),
+						},
+					},
+				},
+				userManagerParams: userManagerParams{
+					getUserParams: getUserParams{
+						{
+							screenName: screenName.IdentScreenName(),
+							result: &state.User{
+								IdentScreenName:   screenName.IdentScreenName(),
+								DisplayScreenName: screenName,
+							},
+						},
+					},
+				},
+				accountManagerParams: accountManagerParams{
+					accountManagerConfirmStatusParams: accountManagerConfirmStatusParams{
+						{
+							screenName:    screenName.IdentScreenName(),
+							confirmStatus: true,
+						},
+					},
+				},
+				bartItemManagerParams: bartItemManagerParams{
+					buddyIconMetadataParams: buddyIconMetadataParams{
+						{
+							screenName: screenName.IdentScreenName(),
+							result:     nil,
+						},
+					},
+				},
+			},
+			wantSess: func(instance *state.SessionInstance) bool {
+				want := state.ClientInfo{
+					ID:        "AOL Instant Messenger, version 5.2.3255/WIN32",
+					IDNum:     4,
+					MajorVer:  1,
+					MinorVer:  75,
+					LesserVer: 9,
+				}
+				return assert.Equal(t, want, instance.ClientInfo())
 			},
 		},
 	}

--- a/foodgroup/helpers_test.go
+++ b/foodgroup/helpers_test.go
@@ -927,7 +927,7 @@ func sessOptKerberosAuth(instance *state.SessionInstance) {
 // sessClientID sets the client ID
 func sessClientID(clientID string) func(instance *state.SessionInstance) {
 	return func(instance *state.SessionInstance) {
-		instance.SetClientID(clientID)
+		instance.SetClientInfo(state.ClientInfo{ID: clientID})
 	}
 }
 

--- a/foodgroup/locate.go
+++ b/foodgroup/locate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/mk6i/open-oscar-server/state"
@@ -116,6 +117,35 @@ func (s LocateService) SetInfo(ctx context.Context, instance *state.SessionInsta
 		}
 	}
 
+	// update client capabilities (buddy icon, chat, etc...)
+	b, hasCaps := inBody.Bytes(wire.LocateTLVTagsInfoCapabilities)
+	if hasCaps {
+		if len(b)%16 != 0 {
+			return errors.New("capability list must be array of 16-byte values")
+		}
+		var caps [][16]byte
+		for i := 0; i < len(b); i += 16 {
+			var c [16]byte
+			copy(c[:], b[i:i+16])
+			if _, found := omitCaps[c]; found {
+				continue
+			}
+			caps = append(caps, c)
+		}
+		instance.SetCaps(caps)
+	}
+
+	// Detect mobile/wireless clients by capability UUID or login version.
+	// Detection must run before any buddy arrival broadcast below (away
+	// message or capabilities) so that the wireless flag is included in
+	// whichever broadcast fires. The flag is intentionally sticky (set, but
+	// never cleared): the client version is fixed at login, so there is no
+	// "unset" signal for version-based detection, and real clients do not
+	// change capabilities mid-session.
+	if isMobileClient(instance.Caps(), instance.ClientInfo()) {
+		instance.SetUserInfoFlag(wire.OServiceUserFlagWireless)
+	}
+
 	// broadcast away message change to buddies
 	if awayMsg, hasAwayMsg := inBody.String(wire.LocateTLVTagsInfoUnavailableData); hasAwayMsg {
 		if awayMsg != "" {
@@ -131,25 +161,9 @@ func (s LocateService) SetInfo(ctx context.Context, instance *state.SessionInsta
 		}
 	}
 
-	// update client capabilities (buddy icon, chat, etc...)
-	if b, hasCaps := inBody.Bytes(wire.LocateTLVTagsInfoCapabilities); hasCaps {
-		if len(b)%16 != 0 {
-			return errors.New("capability list must be array of 16-byte values")
-		}
-		var caps [][16]byte
-		for i := 0; i < len(b); i += 16 {
-			var c [16]byte
-			copy(c[:], b[i:i+16])
-			if _, found := omitCaps[c]; found {
-				continue
-			}
-			caps = append(caps, c)
-		}
-		instance.SetCaps(caps)
-		if instance.SignonComplete() {
-			if err := s.buddyBroadcaster.BroadcastBuddyArrived(ctx, instance.IdentScreenName(), instance.Session().TLVUserInfo()); err != nil {
-				return err
-			}
+	if hasCaps && instance.SignonComplete() {
+		if err := s.buddyBroadcaster.BroadcastBuddyArrived(ctx, instance.IdentScreenName(), instance.Session().TLVUserInfo()); err != nil {
+			return err
 		}
 	}
 
@@ -322,4 +336,19 @@ func (s LocateService) DirInfo(ctx context.Context, inFrame wire.SNACFrame, inBo
 		},
 		Body: reply,
 	}, nil
+}
+
+// isMobileClient detects mobile/wireless clients by capability UUID or by
+// client ID + version from login TLVs 0x0016–0x0018. See
+// wire.KnownMobileClients for the known signatures and their sourcing.
+func isMobileClient(caps [][16]byte, info state.ClientInfo) bool {
+	if slices.Contains(caps, [16]byte(wire.CapMobileClient)) {
+		return true
+	}
+	for _, sig := range wire.KnownMobileClients {
+		if sig.Matches(info.IDNum, info.MajorVer, info.MinorVer, info.LesserVer) {
+			return true
+		}
+	}
+	return false
 }

--- a/foodgroup/locate_test.go
+++ b/foodgroup/locate_test.go
@@ -2,9 +2,11 @@ package foodgroup
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -759,6 +761,62 @@ func TestLocateService_SetInfo(t *testing.T) {
 				assert.True(t, session.Instance(1).Profile().IsZero())
 			},
 		},
+		{
+			name: "clear away message during sign on flow",
+			instance: func() *state.SessionInstance {
+				instance := newTestInstance("user_screen_name")
+				instance.SetUserInfoFlag(wire.OServiceUserFlagUnavailable)
+				instance.SetAwayMessage("this is my away message!")
+				return instance
+			}(),
+			inBody: wire.SNAC_0x02_0x04_LocateSetInfo{
+				TLVRestBlock: wire.TLVRestBlock{
+					TLVList: wire.TLVList{
+						wire.NewTLVBE(wire.LocateTLVTagsInfoUnavailableData, ""),
+					},
+				},
+			},
+			mockParams: mockParams{
+				buddyBroadcasterParams: buddyBroadcasterParams{
+					broadcastBuddyArrivedParams: broadcastBuddyArrivedParams{},
+				},
+			},
+			checkSession: func(t *testing.T, session *state.Session) {
+				assert.Zero(t, session.Instance(1).UserInfoBitmask()&wire.OServiceUserFlagUnavailable)
+				awayMsg, _ := session.Instance(1).AwayMessage()
+				assert.Empty(t, awayMsg)
+			},
+		},
+		{
+			name: "clear away message after sign on flow",
+			instance: func() *state.SessionInstance {
+				instance := newTestInstance("user_screen_name", sessOptSignonComplete)
+				instance.SetUserInfoFlag(wire.OServiceUserFlagUnavailable)
+				instance.SetAwayMessage("this is my away message!")
+				return instance
+			}(),
+			inBody: wire.SNAC_0x02_0x04_LocateSetInfo{
+				TLVRestBlock: wire.TLVRestBlock{
+					TLVList: wire.TLVList{
+						wire.NewTLVBE(wire.LocateTLVTagsInfoUnavailableData, ""),
+					},
+				},
+			},
+			mockParams: mockParams{
+				buddyBroadcasterParams: buddyBroadcasterParams{
+					broadcastBuddyArrivedParams: broadcastBuddyArrivedParams{
+						{
+							screenName: state.DisplayScreenName("user_screen_name"),
+						},
+					},
+				},
+			},
+			checkSession: func(t *testing.T, session *state.Session) {
+				assert.Zero(t, session.Instance(1).UserInfoBitmask()&wire.OServiceUserFlagUnavailable)
+				awayMsg, _ := session.Instance(1).AwayMessage()
+				assert.Empty(t, awayMsg)
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -835,6 +893,163 @@ func TestLocateService_SetInfo_SetCaps(t *testing.T) {
 		{9, 70, 19, 70, 76, 127, 17, 209, 130, 34, 68, 69, 83, 84, 0, 0},
 	}
 	assert.ElementsMatch(t, expect, instance.Session().Caps())
+}
+
+func TestLocateService_SetInfo_WirelessFlag(t *testing.T) {
+	cases := []struct {
+		name     string
+		caps     []byte
+		wantFlag bool
+	}{
+		{
+			name:     "mobile client cap sets wireless flag",
+			caps:     wire.CapMobileClient[:],
+			wantFlag: true,
+		},
+		{
+			name:     "non-mobile cap does not set wireless flag",
+			caps:     wire.CapChat[:],
+			wantFlag: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+			instance := newTestInstance("screen-name")
+			inBody := wire.SNAC_0x02_0x04_LocateSetInfo{
+				TLVRestBlock: wire.TLVRestBlock{
+					TLVList: wire.TLVList{
+						wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, tc.caps),
+					},
+				},
+			}
+			assert.NoError(t, svc.SetInfo(context.Background(), instance, inBody))
+			hasFlag := instance.UserInfoBitmask()&wire.OServiceUserFlagWireless != 0
+			assert.Equal(t, tc.wantFlag, hasFlag)
+		})
+	}
+}
+
+func TestLocateService_SetInfo_WirelessFlagPersistsAfterMobileCapRemoved(t *testing.T) {
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	instance := newTestInstance("screen-name")
+
+	makeBody := func(caps []byte) wire.SNAC_0x02_0x04_LocateSetInfo {
+		return wire.SNAC_0x02_0x04_LocateSetInfo{
+			TLVRestBlock: wire.TLVRestBlock{
+				TLVList: wire.TLVList{
+					wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, caps),
+				},
+			},
+		}
+	}
+
+	mobileCap := wire.CapMobileClient
+	require.NoError(t, svc.SetInfo(context.Background(), instance, makeBody(mobileCap[:])))
+	assert.NotZero(t, instance.UserInfoBitmask()&wire.OServiceUserFlagWireless, "wireless flag should be set after mobile cap")
+
+	chatCap := wire.CapChat
+	require.NoError(t, svc.SetInfo(context.Background(), instance, makeBody(chatCap[:])))
+	assert.NotZero(t, instance.UserInfoBitmask()&wire.OServiceUserFlagWireless, "wireless flag should persist after removing mobile cap")
+}
+
+func TestLocateService_SetInfo_WirelessFlagSetButNotBroadcastBeforeSignon(t *testing.T) {
+	// Before signon completes there is nobody to notify, so no buddy arrival
+	// broadcast should fire — but the wireless flag must still be recorded on
+	// the instance so it is included in the initial arrival broadcast sent
+	// once signon completes. The mock broadcaster has no expectations set, so
+	// any BroadcastBuddyArrived call fails the test.
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	svc.buddyBroadcaster = newMockbuddyBroadcaster(t)
+
+	instance := newTestInstance("screen-name") // signon not complete
+	inBody := wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, wire.CapMobileClient[:]),
+			},
+		},
+	}
+	require.NoError(t, svc.SetInfo(context.Background(), instance, inBody))
+	assert.NotZero(t, instance.UserInfoBitmask()&wire.OServiceUserFlagWireless, "wireless flag should be set even before signon completes")
+}
+
+func TestLocateService_SetInfo_WirelessFlagIncludedInCapsBroadcast(t *testing.T) {
+	// the buddy arrival broadcast triggered by a post-signon capabilities
+	// update must include the wireless flag in the broadcast user info
+	buddyUpdateBroadcaster := newMockbuddyBroadcaster(t)
+	buddyUpdateBroadcaster.EXPECT().
+		BroadcastBuddyArrived(mock.Anything, state.NewIdentScreenName("screen-name"), mock.MatchedBy(func(userInfo wire.TLVUserInfo) bool {
+			flags, _ := userInfo.Uint16BE(wire.OServiceUserInfoUserFlags)
+			return flags&wire.OServiceUserFlagWireless != 0
+		})).
+		Return(nil)
+
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	svc.buddyBroadcaster = buddyUpdateBroadcaster
+
+	instance := newTestInstance("screen-name", sessOptSignonComplete)
+	inBody := wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, wire.CapMobileClient[:]),
+			},
+		},
+	}
+	assert.NoError(t, svc.SetInfo(context.Background(), instance, inBody))
+}
+
+func TestLocateService_SetInfo_WirelessFlagIncludedInAwayMessageBroadcast(t *testing.T) {
+	// the buddy arrival broadcast triggered by an away-message update must
+	// include the wireless flag in the broadcast user info, even when the
+	// same SetInfo call carries no capabilities TLV (version-based mobile
+	// detection relies solely on ClientInfo restored at login)
+	buddyUpdateBroadcaster := newMockbuddyBroadcaster(t)
+	buddyUpdateBroadcaster.EXPECT().
+		BroadcastBuddyArrived(mock.Anything, state.NewIdentScreenName("screen-name"), mock.MatchedBy(func(userInfo wire.TLVUserInfo) bool {
+			flags, _ := userInfo.Uint16BE(wire.OServiceUserInfoUserFlags)
+			return flags&wire.OServiceUserFlagWireless != 0
+		})).
+		Return(nil)
+
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	svc.buddyBroadcaster = buddyUpdateBroadcaster
+
+	instance := newTestInstance("screen-name", sessOptSignonComplete)
+	instance.SetClientInfo(state.ClientInfo{IDNum: 4, MajorVer: 1, MinorVer: 75})
+
+	inBody := wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoUnavailableData, "brb"),
+			},
+		},
+	}
+	assert.NoError(t, svc.SetInfo(context.Background(), instance, inBody))
+}
+
+func TestLocateService_SetInfo_CapsBroadcastError(t *testing.T) {
+	// a buddy arrival broadcast failure triggered by a post-signon
+	// capabilities update must propagate the error to the caller
+	wantErr := errors.New("broadcast failed")
+	buddyUpdateBroadcaster := newMockbuddyBroadcaster(t)
+	buddyUpdateBroadcaster.EXPECT().
+		BroadcastBuddyArrived(mock.Anything, state.NewIdentScreenName("screen-name"), mock.Anything).
+		Return(wantErr)
+
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	svc.buddyBroadcaster = buddyUpdateBroadcaster
+
+	instance := newTestInstance("screen-name", sessOptSignonComplete)
+	inBody := wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, wire.CapChat[:]),
+			},
+		},
+	}
+	assert.ErrorIs(t, svc.SetInfo(context.Background(), instance, inBody), wantErr)
 }
 
 func TestLocateService_RightsQuery(t *testing.T) {
@@ -988,6 +1203,146 @@ func TestLocateService_DirInfo(t *testing.T) {
 			outputSNAC, err := svc.DirInfo(context.Background(), tt.inputSNAC.Frame, tt.inputSNAC.Body.(wire.SNAC_0x02_0x0B_LocateGetDirInfo))
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectOutput, outputSNAC)
+		})
+	}
+}
+
+func TestLocateService_SetInfo_WirelessFlagByVersion(t *testing.T) {
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+
+	cases := []struct {
+		name     string
+		info     state.ClientInfo
+		wantFlag bool
+	}{
+		{
+			name:     "client ID 4 + version 1.75 sets wireless flag",
+			info:     state.ClientInfo{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			wantFlag: true,
+		},
+		{
+			name:     "client ID 284 (MX240a) sets wireless flag",
+			info:     state.ClientInfo{IDNum: 284},
+			wantFlag: true,
+		},
+		{
+			name:     "client ID 265 (normal AIM) does not set wireless flag",
+			info:     state.ClientInfo{IDNum: 265},
+			wantFlag: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := newTestInstance("screen-name")
+			instance.SetClientInfo(tc.info)
+			assert.NoError(t, svc.SetInfo(context.Background(), instance, wire.SNAC_0x02_0x04_LocateSetInfo{}))
+			hasFlag := instance.UserInfoBitmask()&wire.OServiceUserFlagWireless != 0
+			assert.Equal(t, tc.wantFlag, hasFlag)
+		})
+	}
+}
+
+func TestLocateService_SetInfo_NormalDesktopClientNotFlaggedWireless(t *testing.T) {
+	// A real AIM 5.2 desktop login, per the captured "Normal Login" packet
+	// signature (client ID 265, major 5, minor 2), sending the standard
+	// desktop capability set (chat, voice, file transfer, direct ICBM,
+	// avatar) and an away message. None of that should ever cause the
+	// wireless flag to be set or broadcast, even though "Mobile Login"
+	// spoofers send an identical capability list and differ only in the
+	// client ID/version TLVs.
+	buddyUpdateBroadcaster := newMockbuddyBroadcaster(t)
+	buddyUpdateBroadcaster.EXPECT().
+		BroadcastBuddyArrived(mock.Anything, state.NewIdentScreenName("screen-name"), mock.MatchedBy(func(userInfo wire.TLVUserInfo) bool {
+			flags, _ := userInfo.Uint16BE(wire.OServiceUserInfoUserFlags)
+			return flags&wire.OServiceUserFlagWireless == 0
+		})).
+		Return(nil).
+		Times(2) // once for the caps update, once for the away message
+
+	svc := NewLocateService(nil, newMockMessageRelayer(t), nil, nil, nil, nil)
+	svc.buddyBroadcaster = buddyUpdateBroadcaster
+
+	instance := newTestInstance("screen-name", sessOptSignonComplete)
+	instance.SetClientInfo(state.ClientInfo{
+		ID:       "AOL Instant Messenger, version 5.2.3255/WIN32",
+		IDNum:    265,
+		MajorVer: 5,
+		MinorVer: 2,
+	})
+
+	var caps []byte
+	for _, c := range []uuid.UUID{wire.CapChat, wire.CapVoiceChat, wire.CapFileTransfer, wire.CapDirectICBM, wire.CapAvatarService} {
+		caps = append(caps, c[:]...)
+	}
+	require.NoError(t, svc.SetInfo(context.Background(), instance, wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, caps),
+			},
+		},
+	}))
+	assert.Zero(t, instance.UserInfoBitmask()&wire.OServiceUserFlagWireless)
+
+	require.NoError(t, svc.SetInfo(context.Background(), instance, wire.SNAC_0x02_0x04_LocateSetInfo{
+		TLVRestBlock: wire.TLVRestBlock{
+			TLVList: wire.TLVList{
+				wire.NewTLVBE(wire.LocateTLVTagsInfoUnavailableData, "brb"),
+			},
+		},
+	}))
+	assert.Zero(t, instance.UserInfoBitmask()&wire.OServiceUserFlagWireless)
+}
+
+func TestIsMobileClient(t *testing.T) {
+	cases := []struct {
+		name       string
+		caps       [][16]byte
+		info       state.ClientInfo
+		wantMobile bool
+	}{
+		{
+			name:       "CapMobileClient UUID returns true",
+			caps:       [][16]byte{[16]byte(wire.CapMobileClient)},
+			wantMobile: true,
+		},
+		{
+			name:       "no mobile caps or version returns false",
+			caps:       [][16]byte{},
+			wantMobile: false,
+		},
+		{
+			name:       "client ID 4 + version 1.75 (mobile login spoof signature) returns true",
+			info:       state.ClientInfo{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			wantMobile: true,
+		},
+		{
+			name:       "client ID 4 + wrong version returns false",
+			info:       state.ClientInfo{IDNum: 4, MajorVer: 5, MinorVer: 2},
+			wantMobile: false,
+		},
+		{
+			name:       "client ID 284 (MX240a) returns true",
+			info:       state.ClientInfo{IDNum: 284},
+			wantMobile: true,
+		},
+		{
+			name:       "client ID 265 (normal AIM) returns false",
+			info:       state.ClientInfo{IDNum: 265},
+			wantMobile: false,
+		},
+		{
+			name:       "cap + version both present, still returns true",
+			caps:       [][16]byte{[16]byte(wire.CapMobileClient)},
+			info:       state.ClientInfo{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			wantMobile: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isMobileClient(tc.caps, tc.info)
+			assert.Equal(t, tc.wantMobile, got)
 		})
 	}
 }

--- a/foodgroup/oservice_test.go
+++ b/foodgroup/oservice_test.go
@@ -21,6 +21,18 @@ import (
 func TestOServiceService_ServiceRequest(t *testing.T) {
 	chatRoom := state.NewChatRoom("the-chat-room", state.NewIdentScreenName(""), state.PrivateExchange)
 
+	// makeCookieData builds expected serialized ServerCookie bytes for mock expectations.
+	makeCookieData := func(service uint16, screenName state.DisplayScreenName, chatCookie string) []byte {
+		buf := &bytes.Buffer{}
+		assert.NoError(t, wire.MarshalBE(state.ServerCookie{
+			Service:    service,
+			ScreenName: screenName,
+			ChatCookie: chatCookie,
+			SessionNum: 1,
+		}, buf))
+		return buf.Bytes()
+	}
+
 	cases := []struct {
 		// name is the unit test name
 		name string
@@ -76,15 +88,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x07, // admin service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.Admin, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -125,15 +129,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x18, // alert service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.Alert, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -174,15 +170,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x10, // chatnav service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.BART, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -223,15 +211,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x0d, // chatnav service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.ChatNav, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -290,15 +270,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 					cookieBakerParams: cookieBakerParams{
 						cookieIssueParams: cookieIssueParams{
 							{
-								dataIn: []byte{
-									0x00, 0x0e, // chat service,
-									0x02, 'm', 'e', // screen name
-									0x00, // no client ID
-									0x11, '4', '-', '0', '-', 't', 'h', 'e', '-', 'c', 'h', 'a', 't', '-', 'r', 'o', 'o', 'm',
-									0x0,  // multi conn flag
-									0x0,  // kerberos flag
-									0x01, // session num
-								},
+								dataIn:    makeCookieData(wire.Chat, "me", "4-0-the-chat-room"),
 								cookieOut: []byte("the-auth-cookie"),
 							},
 						},
@@ -340,15 +312,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x0F, // chatnav service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.ODir, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -474,15 +438,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x07, // admin service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.Admin, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -528,15 +484,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x18, // alert service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.Alert, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -582,15 +530,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x10, // BART service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.BART, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -636,15 +576,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x0d, // chatnav service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.ChatNav, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},
@@ -704,15 +636,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 					cookieBakerParams: cookieBakerParams{
 						cookieIssueParams: cookieIssueParams{
 							{
-								dataIn: []byte{
-									0x00, 0x0e, // chat service,
-									0x02, 'm', 'e', // screen name
-									0x00, // no client ID
-									0x11, '4', '-', '0', '-', 't', 'h', 'e', '-', 'c', 'h', 'a', 't', '-', 'r', 'o', 'o', 'm',
-									0x0,  // multi conn flag
-									0x0,  // kerberos flag
-									0x01, // session num
-								},
+								dataIn:    makeCookieData(wire.Chat, "me", "4-0-the-chat-room"),
 								cookieOut: []byte("the-auth-cookie"),
 							},
 						},
@@ -759,15 +683,7 @@ func TestOServiceService_ServiceRequest(t *testing.T) {
 				cookieBakerParams: cookieBakerParams{
 					cookieIssueParams: cookieIssueParams{
 						{
-							dataIn: []byte{
-								0x00, 0x0F, // ODir service
-								0x02, 'm', 'e',
-								0x0,  // no client ID
-								0x0,  // no chat cookie
-								0x0,  // multi conn flag
-								0x0,  // kerberos flag
-								0x01, // session num
-							},
+							dataIn:    makeCookieData(wire.ODir, "me", ""),
 							cookieOut: []byte("the-cookie"),
 						},
 					},

--- a/server/toc/cmd_client_test.go
+++ b/server/toc/cmd_client_test.go
@@ -5852,6 +5852,31 @@ func TestOSCARProxy_RecvClientCmd_SetCaps(t *testing.T) {
 			wantMsg: []string{},
 		},
 		{
+			name:     "set mobile client cap forwarded to locate service",
+			me:       newTestSession("me"),
+			givenCmd: []byte(`toc_set_caps 09461323-4C7F-11D1-8222-444553540000`),
+			mockParams: mockParams{
+				locateParams: locateParams{
+					setInfoParams: setInfoParams{
+						{
+							me: state.NewIdentScreenName("me"),
+							inBody: wire.SNAC_0x02_0x04_LocateSetInfo{
+								TLVRestBlock: wire.TLVRestBlock{
+									TLVList: wire.TLVList{
+										wire.NewTLVBE(wire.LocateTLVTagsInfoCapabilities, []uuid.UUID{
+											wire.CapMobileClient,
+											wire.CapChat,
+										}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantMsg: []string{},
+		},
+		{
 			name:     "set capabilities with comma-separated list (TameClone format)",
 			me:       newTestSession("me"),
 			givenCmd: []byte(`toc_set_caps 748F2420-6287-11D1-8222-444553540000,1348,134B,1341,1343,1FF,1345,1346,1347,`),

--- a/state/cookie.go
+++ b/state/cookie.go
@@ -27,6 +27,14 @@ type ServerCookie struct {
 	// KerberosAuth indicates whether the client used Kerberos for authentication.
 	KerberosAuth uint8
 	SessionNum   uint8
+	// ClientIDNum is the numeric client ID (login TLV 0x0016).
+	ClientIDNum uint16
+	// MajorVer is the client major version (login TLV 0x0017).
+	MajorVer uint16
+	// MinorVer is the client minor version (login TLV 0x0018).
+	MinorVer uint16
+	// LesserVer is the client lesser version (login TLV 0x0019).
+	LesserVer uint16
 }
 
 func NewHMACCookieBaker() (HMACCookieBaker, error) {

--- a/state/session.go
+++ b/state/session.go
@@ -741,7 +741,7 @@ func (s *Session) Caps() [][16]byte {
 	caps := make(map[[16]byte]bool)
 
 	for _, instance := range s.instances {
-		for _, c := range instance.caps() {
+		for _, c := range instance.Caps() {
 			caps[c] = true
 		}
 	}
@@ -952,6 +952,20 @@ func (s *Session) userInfo() wire.TLVList {
 	return tlvs
 }
 
+// ClientInfo describes the client software identity reported at login.
+type ClientInfo struct {
+	// ID is the client name and version string (login TLV 0x0003).
+	ID string
+	// IDNum is the numeric client ID (login TLV 0x0016).
+	IDNum uint16
+	// MajorVer is the client major version (login TLV 0x0017).
+	MajorVer uint16
+	// MinorVer is the client minor version (login TLV 0x0018).
+	MinorVer uint16
+	// LesserVer is the client lesser version (login TLV 0x0019).
+	LesserVer uint16
+}
+
 // SessionInstance represents a single client connection instance within a user's
 // session. Multiple SessionInstance objects can belong to the same Session,
 // allowing a user to maintain concurrent connections from different clients or
@@ -980,7 +994,7 @@ type SessionInstance struct {
 	kerberosAuth   bool
 
 	// Per-session client information
-	clientID          string
+	clientInfo        ClientInfo
 	capabilities      [][16]byte
 	foodGroupVersions [wire.MDir + 1]uint16
 	multiConnFlag     wire.MultiConnFlag
@@ -1022,11 +1036,11 @@ func (s *SessionInstance) ChatRoomCookie() string {
 	return s.session.ChatRoomCookie()
 }
 
-// ClientID retrieves the instance's client ID.
-func (s *SessionInstance) ClientID() string {
+// ClientInfo returns the client software identity reported at login.
+func (s *SessionInstance) ClientInfo() ClientInfo {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
-	return s.clientID
+	return s.clientInfo
 }
 
 // DisplayScreenName returns the user's display screen name.
@@ -1049,11 +1063,11 @@ func (s *SessionInstance) UIN() uint32 {
 	return s.session.UIN()
 }
 
-// SetClientID sets the instance's client ID.
-func (s *SessionInstance) SetClientID(clientID string) {
+// SetClientInfo sets the client software identity reported at login.
+func (s *SessionInstance) SetClientInfo(info ClientInfo) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	s.clientID = clientID
+	s.clientInfo = info
 }
 
 // SetTOC2 sets this instance to TOC2. supportsTOC2MsgEnc is true for toc2_login (encoded messaging), false for toc2_signon.
@@ -1406,6 +1420,13 @@ func (s *SessionInstance) SetAwayMessage(awayMessage string) {
 	s.awayMsg = awayMessage
 }
 
+// Caps returns the instance's capability UUIDs.
+func (s *SessionInstance) Caps() [][16]byte {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	return s.capabilities
+}
+
 // SetCaps sets capability UUIDs for the instance.
 func (s *SessionInstance) SetCaps(caps [][16]byte) {
 	s.mutex.Lock()
@@ -1506,13 +1527,6 @@ func (s *SessionInstance) ICQDCInfo() wire.ICQDCInfo {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 	return s.icqDCInfo
-}
-
-// caps retrieves instance capabilities.
-func (s *SessionInstance) caps() [][16]byte {
-	s.mutex.RLock()
-	defer s.mutex.RUnlock()
-	return s.capabilities
 }
 
 //

--- a/state/session_test.go
+++ b/state/session_test.go
@@ -167,12 +167,19 @@ func TestSession_SetAndGetUIN(t *testing.T) {
 	assert.Equal(t, uin, s.UIN())
 }
 
-func TestSession_SetAndGetClientID(t *testing.T) {
+func TestSession_SetAndGetClientInfo(t *testing.T) {
 	s := NewSession().AddInstance()
-	assert.Empty(t, s.ClientID())
-	clientID := "AIM Client ID"
-	s.SetClientID(clientID)
-	assert.Equal(t, clientID, s.ClientID())
+	assert.Zero(t, s.ClientInfo())
+
+	info := ClientInfo{
+		ID:        "AIM Client ID",
+		IDNum:     4,
+		MajorVer:  1,
+		MinorVer:  75,
+		LesserVer: 0,
+	}
+	s.SetClientInfo(info)
+	assert.Equal(t, info, s.ClientInfo())
 }
 
 func TestSession_SetAndGetKerberosAuth(t *testing.T) {

--- a/wire/snacs.go
+++ b/wire/snacs.go
@@ -97,6 +97,10 @@ const (
 	LoginTLVTagsScreenName                uint16 = 0x01
 	LoginTLVTagsRoastedPassword           uint16 = 0x02
 	LoginTLVTagsClientIdentity            uint16 = 0x03
+	LoginTLVTagsClientIDNumber            uint16 = 0x0016
+	LoginTLVTagsMajorVersion              uint16 = 0x0017
+	LoginTLVTagsMinorVersion              uint16 = 0x0018
+	LoginTLVTagsLesserVersion             uint16 = 0x0019
 	LoginTLVTagsReconnectHere             uint16 = 0x05
 	LoginTLVTagsAuthorizationCookie       uint16 = 0x06
 	LoginTLVTagsErrorSubcode              uint16 = 0x08
@@ -139,6 +143,39 @@ const (
 //
 // Capability IDs
 //
+
+// ClientVersion identifies a client by the ID and version it reports in
+// login TLVs 0x0016 (Client ID Number), 0x0017 (Major Version), 0x0018
+// (Minor Version), and 0x0019 (Lesser Version). A zero MajorVer/MinorVer/
+// LesserVer means "don't care" — no known real client reports 0 for the
+// major/minor field, since that would mean "no version", and mobile
+// signatures observed in packet captures report LesserVer 0, so it is left
+// as a wildcard for them.
+type ClientVersion struct {
+	IDNum     uint16
+	MajorVer  uint16
+	MinorVer  uint16
+	LesserVer uint16
+}
+
+// Matches reports whether the given client ID/major/minor/lesser version
+// matches this signature. Zero-valued MajorVer/MinorVer/LesserVer fields on
+// the signature are treated as wildcards.
+func (v ClientVersion) Matches(idNum, majorVer, minorVer, lesserVer uint16) bool {
+	if v.IDNum != idNum {
+		return false
+	}
+	if v.MajorVer != 0 && v.MajorVer != majorVer {
+		return false
+	}
+	if v.MinorVer != 0 && v.MinorVer != minorVer {
+		return false
+	}
+	if v.LesserVer != 0 && v.LesserVer != lesserVer {
+		return false
+	}
+	return true
+}
 
 var (
 	// CapChat is the UUID that represents an OSCAR client's ability to chat
@@ -194,10 +231,34 @@ var (
 	CapSupportICQ = uuid.MustParse("0946134D-4C7F-11D1-8222-444553540000")
 	// CapUTF8Messages indicates the client supports UTF-8 messages (AIM)
 	CapUTF8Messages = uuid.MustParse("0946134E-4C7F-11D1-8222-444553540000")
+	// CapMobileClient indicates the client is a hiptop/T-mobile mobile client
+	CapMobileClient = uuid.MustParse("09461323-4C7F-11D1-8222-444553540000")
 
 	//
 	// Full UUIDs (non-short format)
 	//
+
+	//
+	// Known mobile client login signatures. Some mobile/wireless clients
+	// don't advertise CapMobileClient, but can be identified by the client
+	// ID and version they report in login TLVs 0x0016-0x0018 instead.
+	//
+
+	// ClientMobileLoginSpoof is the client ID/version signature sent by
+	// "Mobile Login" toggles in AIM spoofer clients (Sean's OscarStuff
+	// family, n3k0de AimRemix), confirmed via packet capture.
+	ClientMobileLoginSpoof = ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75}
+	// ClientMX240a is the client ID reported by the MX240a wireless handheld
+	// device.
+	ClientMX240a = ClientVersion{IDNum: 284}
+
+	// KnownMobileClients lists all client ID/version signatures known to
+	// belong to a mobile/wireless client that does not advertise
+	// CapMobileClient.
+	KnownMobileClients = []ClientVersion{
+		ClientMobileLoginSpoof,
+		ClientMX240a,
+	}
 
 	// CapRTFMessages indicates the client supports RTF messages (ICQ)
 	CapRTFMessages = uuid.MustParse("97B12751-243C-4334-AD22-D6ABF73F1492")

--- a/wire/snacs_test.go
+++ b/wire/snacs_test.go
@@ -292,6 +292,104 @@ func TestCapabilityUUIDs(t *testing.T) {
 	}
 }
 
+func TestClientVersion_Matches(t *testing.T) {
+	tests := []struct {
+		name      string
+		sig       ClientVersion
+		idNum     uint16
+		majorVer  uint16
+		minorVer  uint16
+		lesserVer uint16
+		expected  bool
+	}{
+		{
+			name:     "exact match on all fields",
+			sig:      ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			idNum:    4,
+			majorVer: 1,
+			minorVer: 75,
+			expected: true,
+		},
+		{
+			name:      "lesser version constrained, exact match",
+			sig:       ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75, LesserVer: 9},
+			idNum:     4,
+			majorVer:  1,
+			minorVer:  75,
+			lesserVer: 9,
+			expected:  true,
+		},
+		{
+			name:      "lesser version constrained, wrong lesser version",
+			sig:       ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75, LesserVer: 9},
+			idNum:     4,
+			majorVer:  1,
+			minorVer:  75,
+			lesserVer: 0,
+			expected:  false,
+		},
+		{
+			name:      "lesser version wildcard ignores lesser version",
+			sig:       ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			idNum:     4,
+			majorVer:  1,
+			minorVer:  75,
+			lesserVer: 42,
+			expected:  true,
+		},
+		{
+			name:     "same client ID, wrong major version",
+			sig:      ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			idNum:    4,
+			majorVer: 5,
+			minorVer: 75,
+			expected: false,
+		},
+		{
+			name:     "same client ID, wrong minor version",
+			sig:      ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			idNum:    4,
+			majorVer: 1,
+			minorVer: 2,
+			expected: false,
+		},
+		{
+			name:     "different client ID",
+			sig:      ClientVersion{IDNum: 4, MajorVer: 1, MinorVer: 75},
+			idNum:    265,
+			majorVer: 1,
+			minorVer: 75,
+			expected: false,
+		},
+		{
+			name:     "ID-only signature ignores version",
+			sig:      ClientVersion{IDNum: 284},
+			idNum:    284,
+			majorVer: 9,
+			minorVer: 9,
+			expected: true,
+		},
+		{
+			name:     "ID-only signature, wrong ID",
+			sig:      ClientVersion{IDNum: 284},
+			idNum:    4,
+			majorVer: 0,
+			minorVer: 0,
+			expected: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.sig.Matches(tt.idNum, tt.majorVer, tt.minorVer, tt.lesserVer))
+		})
+	}
+}
+
+func TestKnownMobileClients(t *testing.T) {
+	assert.Contains(t, KnownMobileClients, ClientMobileLoginSpoof)
+	assert.Contains(t, KnownMobileClients, ClientMX240a)
+}
+
 func TestShortCapHexToUUID(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
### Summary
Set the wireless user info flag (OServiceUserFlagWireless) for mobile clients, detected either by capability UUID (CapMobileClient) or by known mobile client ID/version signatures (client ID 4 v1.75.x, MX240a client ID 284).

The client version TLVs (0x16-0x19) are only present at auth-stage login, so they are carried through the auth cookie and restored onto the session instance upon BOS connection.

The client ID 4 v1.75.x was determined by inspecting old clients found in the [aolunderground-proggies](https://github.com/ssstonebraker/aolunderground-proggies) repo. AimRemix4 and Sean's OscarStuff both use these values when the user enables "mobile" login. ecAdminBlue and Miranda AimOscar both send the CapMobileClient UUID.

I also made the Motorola MX240 handheld AIM client is detected as a mobile client, mostly because I have one and wanted it that way. There's no evidence that AOL marked this client as mobile back in the day, and it does not send the CapMobileClient UUID, but it felt appropriate since it is a mobile device.

I tried to make this easy to extend in case we find more mobile indicators in the future, see `KnownMobileClients` in snacs.go

### Testing
I used AimRemix4 to login without and with the mobile checkbox enabled. When mobile, I can see the mobile icon in the buddy list for that user, and on AIM 5.5 the IM window shows it as a mobile client.
<img width="1988" height="648" alt="image" src="https://github.com/user-attachments/assets/21a676a8-3b9c-41dd-914d-2eebf4d95696" />


I logged into the Motorola MX240 device and verified it shows up as mobile
<img width="528" height="246" alt="image" src="https://github.com/user-attachments/assets/b3cba2ae-ed26-4d88-b303-edefbc5c5a17" />


I did earlier testing with ecAdminBlue, but there is a separate unrelated bug with this client that prevents logon. I thought I had the fix in a git stash but alas it's gone, so I couldn't demonstrate it working on the final iteration of my changes for a screenshot.

Unit tests pass

